### PR TITLE
Update PHP examples to use the pecl lib

### DIFF
--- a/php-pecl/README.md
+++ b/php-pecl/README.md
@@ -1,0 +1,48 @@
+# PHP code for RabbitMQ tutorial #
+
+Here you can find a PHP code examples from [RabbitMQ
+tutorials](http://www.rabbitmq.com/getstarted.html).
+
+
+## Requirements ##
+
+To run the examples you need a running RabbitMQ server.
+
+Additionally you need the [PHP AMQP PECL package](http://php.net/manual/en/book.amqp.php)
+
+## Code
+
+[Tutorial one: "Hello World!"](http://www.rabbitmq.com/tutorial-one-python.html):
+
+    php send.php
+    php receive.php
+
+
+[Tutorial two: Work Queues](http://www.rabbitmq.com/tutorial-two-python.html):
+
+    php new_task.php "A very hard task which takes two seconds.."
+    php worker.php
+
+
+[Tutorial three: Publish/Subscribe](http://www.rabbitmq.com/tutorial-three-python.html)
+
+    php receive_logs.php
+    php emit_log.php This is the log message
+
+
+[Tutorial four: Routing](http://www.rabbitmq.com/tutorial-four-python.html)
+
+    php receive_logs_direct.php info
+    php emit_log_direct.php info The message
+
+
+[Tutorial five: Topics](http://www.rabbitmq.com/tutorial-five-python.html)
+
+    php receive_logs_topic.php '*.rabbit'
+    php emit_log_topic.php red.rabbit Hello
+
+
+[Tutorial six: RPC](http://www.rabbitmq.com/tutorial-six-python.html):
+
+    php rpc_server.php
+    php rpc_client.php

--- a/php-pecl/emit_log.php
+++ b/php-pecl/emit_log.php
@@ -1,0 +1,17 @@
+<?php
+
+$connection = new AMQPConnection();
+$connection->connect();
+
+$exchange = new AMQPExchange($connection);
+$exchange->declare('logs', AMQP_EX_TYPE_FANOUT);
+
+$message = implode(' ', array_slice($argv, 1));
+if(empty($message)) {
+    $message = "Hello World!";
+}
+$exchange->publish($message, 'logs');
+
+echo " [x] Sent $message\n";
+
+$connection->disconnect();

--- a/php-pecl/emit_log_direct.php
+++ b/php-pecl/emit_log_direct.php
@@ -1,0 +1,23 @@
+<?php
+
+$connection = new AMQPConnection();
+$connection->connect();
+
+$exchange = new AMQPExchange($connection);
+$exchange->declare('direct_logs');
+
+if (count($argv) > 2) {
+    $severity = $argv[1];
+    unset($argv[1]);
+} else {
+    $severity = 'info';
+}
+$message = implode(' ', array_slice($argv, 1));
+if(empty($message)) {
+    $message = "Hello World!";
+}
+$exchange->publish($message, $severity);
+
+echo " [x] Sent $severity:$message\n";
+
+$connection->disconnect();

--- a/php-pecl/emit_log_topic.php
+++ b/php-pecl/emit_log_topic.php
@@ -1,0 +1,23 @@
+<?php
+
+$connection = new AMQPConnection();
+$connection->connect();
+
+$exchange = new AMQPExchange($connection);
+$exchange->declare('topic_logs', AMQP_EX_TYPE_TOPIC);
+
+if (count($argv) > 2) {
+    $routingKey = $argv[1];
+    unset($argv[1]);
+} else {
+    $routingKey = 'anonymous.info';
+}
+$message = implode(' ', array_slice($argv, 1));
+if(empty($message)) {
+    $message = "Hello World!";
+}
+$exchange->publish($message, $routingKey);
+
+echo " [x] Sent $routingKey:$message\n";
+
+$connection->disconnect();

--- a/php-pecl/new_task.php
+++ b/php-pecl/new_task.php
@@ -1,0 +1,26 @@
+<?php
+$connection = new AMQPConnection();
+$connection->connect();
+
+$exchange = new AMQPExchange($connection, '');
+
+$queue = new AMQPQueue($connection);
+$queue->declare('task_queue', AMQP_DURABLE);
+
+$message = implode(' ', array_slice($argv, 1));
+if(empty($message)) {
+    $message = "Hello World!";
+}
+
+$exchange->publish(
+    $message, 
+    'task_queue', 
+    0, 
+    array(
+        'delivery_mode' => 2 # make message persistent
+    )
+);
+
+echo " [x] Sent $message\n";
+
+$connection->disconnect();

--- a/php-pecl/receive.php
+++ b/php-pecl/receive.php
@@ -1,0 +1,20 @@
+<?php
+
+$connection = new AMQPConnection();
+$connection->connect();
+
+$queue = new AMQPQueue($connection);
+$queue->declare('hello');
+
+echo ' [*] Waiting for messages. To exit press CTRL+C', "\n";
+
+$options = array(
+    'min' => 1,
+    'max' => 10,
+    'ack' => true
+);
+while ($messages = $queue->consume($options)) {
+    foreach($messages as $message) {
+        echo " [x] Received {$message['message_body']}\n";
+    }
+}

--- a/php-pecl/receive_logs.php
+++ b/php-pecl/receive_logs.php
@@ -1,0 +1,25 @@
+<?php
+$connection = new AMQPConnection();
+$connection->connect();
+
+$exchange = new AMQPExchange($connection);
+$exchange->declare('logs', AMQP_EX_TYPE_FANOUT);
+
+$name = 'logworker_' . uniqid();
+$queue = new AMQPQueue($connection);
+$queue->declare($name);
+
+$exchange->bind($name, 'logs');
+
+echo ' [*] Waiting for logs. To exit press CTRL+C', "\n";
+
+$options = array(
+    'min' => 1,
+    'max' => 10,
+    'ack' => false
+);
+while ($messages = $queue->consume($options)) {
+    foreach($messages as $message) {
+        echo " [x] Received {$message['message_body']}\n";
+    }
+}

--- a/php-pecl/receive_logs_direct.php
+++ b/php-pecl/receive_logs_direct.php
@@ -1,0 +1,41 @@
+<?php
+
+$connection = new AMQPConnection();
+$connection->connect();
+
+$exchange = new AMQPExchange($connection);
+$exchange->declare('direct_logs');
+
+$name = 'logworker_' . uniqid();
+$queue = new AMQPQueue($connection);
+$queue->declare($name);
+
+$exchange->bind($name, 'direct_logs');
+
+if (count($argv) > 1) {
+    $severities = array_slice($argv, 1);
+} else {
+    echo 'Usage: ' . basename(__FILE__) . " [info] [warning] [error]\n";
+    die(1);
+}
+
+foreach($severities as $severity) {
+    $exchange->bind($name, $severity);
+}
+
+echo ' [*] Waiting for ' . implode($severities, ', ') . ' logs. To exit press CTRL+C', "\n";
+
+$callback = function($message) {
+    echo " [x] {$message['routing_key']}:{$message['message_body']}\n";
+};
+
+$options = array(
+    'min' => 1,
+    'max' => 10,
+    'ack' => false
+);
+while ($messages = $queue->consume($options)) {
+    foreach($messages as $message) {
+        $callback($message);
+    }
+}

--- a/php-pecl/receive_logs_topic.php
+++ b/php-pecl/receive_logs_topic.php
@@ -1,0 +1,41 @@
+<?php
+
+$connection = new AMQPConnection();
+$connection->connect();
+
+$exchange = new AMQPExchange($connection);
+$exchange->declare('topic_logs', AMQP_EX_TYPE_TOPIC);
+
+$name = 'logworker_' . uniqid();
+$queue = new AMQPQueue($connection);
+$queue->declare($name);
+
+$exchange->bind($name, 'direct_logs');
+
+if (count($argv) > 1) {
+    $bindingKeys = array_slice($argv, 1);
+} else {
+    echo 'Usage: ' . basename(__FILE__) . " [binding_key] ...\n";
+    die(1);
+}
+
+foreach($bindingKeys as $key) {
+    $exchange->bind($name, $key);
+}
+
+echo ' [*] Waiting for ' . implode($bindingKeys, ', ') . ' logs. To exit press CTRL+C', "\n";
+
+$callback = function($message) {
+    echo " [x] {$message['routing_key']}:{$message['message_body']}\n";
+};
+
+$options = array(
+    'min' => 1,
+    'max' => 10,
+    'ack' => false
+);
+while ($messages = $queue->consume($options)) {
+    foreach($messages as $message) {
+        $callback($message);
+    }
+}

--- a/php-pecl/rpc_client.php
+++ b/php-pecl/rpc_client.php
@@ -1,0 +1,68 @@
+<?php
+
+class FibonacciRpcClient {
+	protected $connection;
+	protected $exchange;
+	protected $callbackQueue;
+	protected $callbackQueueName;
+	protected $response;
+	protected $corrId;
+
+	public function __construct() {
+		$this->connection = new AMQPConnection();
+        $this->connection->connect();
+
+        $this->exchange = new AMQPExchange($this->connection, '');
+
+        $queue = new AMQPQueue($this->connection);
+        $this->callbackQueueName = 'rpc_' . uniqid();
+        $queue->declare($this->callbackQueueName);
+        $this->callbackQueue = $queue;
+
+	}
+
+	public function onResponse($rep) {
+        $this->response = $rep['message_body'];
+	}
+
+	public function call($n) {
+		$this->response = null;
+		$this->corrId = uniqid();
+
+        $this->exchange->publish(
+			(string) $n,
+            'rpc_queue',
+            0,
+            array(
+                'message_id' => $this->corrId,
+                'reply_to' => $this->callbackQueueName
+            )
+        );
+
+        $options = array(
+            'min' => 1,
+            'max' => 1,
+            'ack' => false
+        );
+
+        while (!$this->response) {
+            while($messages = $this->callbackQueue->consume()) {
+                foreach($messages as $message) {
+                    $this->onResponse($message);
+                }
+                if ($this->response) {
+                    return $this->response;
+                }
+            }
+        }
+	}
+};
+
+$start = 30;
+if (!empty($argv[1])) {
+    $start = $argv[1];
+}
+$fibonacciRpc = new FibonacciRpcClient();
+$response = $fibonacciRpc->call($start);
+
+echo " [.] Got $response\n";

--- a/php-pecl/rpc_server.php
+++ b/php-pecl/rpc_server.php
@@ -1,0 +1,46 @@
+<?php
+
+$connection = new AMQPConnection();
+$connection->connect();
+
+$exchange = new AMQPExchange($connection, '');
+
+$queue = new AMQPQueue($connection);
+$queue->declare('rpc_queue');
+
+function fib($n) {
+	if (!$n) {
+		return 0;
+    }
+	if ($n == 1) {
+		return 1;
+    }
+	return fib($n-1) + fib($n-2);
+}
+
+echo " [x] Awaiting RPC requests\n";
+
+$callback = function($req) use ($queue, $exchange) {
+    $n = intval($req['message_body']);
+    echo " [.] fib($n)\n";
+
+    $msg = fib($n);
+
+    $exchange->publish(
+        $msg,
+        $req['Reply-to']
+    );
+    $queue->ack($req['delivery_tag']);
+
+};
+
+$options = array(
+    'min' => 1,
+    'max' => 1,
+    'ack' => false
+);
+while ($messages = $queue->consume($options)) {
+    foreach($messages as $message) {
+        $callback($message);
+    }
+}

--- a/php-pecl/send.php
+++ b/php-pecl/send.php
@@ -1,0 +1,14 @@
+<?php
+$connection = new AMQPConnection();
+$connection->connect();
+
+$exchange = new AMQPExchange($connection, '');
+
+$queue = new AMQPQueue($connection);
+$queue->declare('hello');
+
+$exchange->publish('Hello World!', 'hello');
+
+echo " [x] Sent 'Hello World!'\n";
+
+$connection->disconnect();

--- a/php-pecl/worker.php
+++ b/php-pecl/worker.php
@@ -1,0 +1,27 @@
+<?php
+// TODO qos
+$connection = new AMQPConnection();
+$connection->connect();
+
+$queue = new AMQPQueue($connection);
+$queue->declare('task_queue', AMQP_DURABLE);
+
+echo ' [*] Waiting for messages. To exit press CTRL+C', "\n";
+
+$callback = function($message) use ($queue) {
+    echo " [x] Received ", $message['message_body'], "\n";
+    sleep(substr_count($message['message_body'], '.'));
+    echo " [x] Done", "\n";
+    $queue->ack($message['delivery_tag']);
+};
+
+$options = array(
+    'min' => 1,
+    'max' => 1,
+    'ack' => false
+);
+while ($messages = $queue->consume($options)) {
+    foreach($messages as $message) {
+        $callback($message);
+    }
+}


### PR DESCRIPTION
Possibly just an RFC, since I'm not sure on the true stability of this pecl package.

However, the pecl lib (http://pecl.php.net/package/amqp) exists, is easier to use, and therefore could do with at least being mentioned.

I've also added examples of use for the two missing tutorials.
