### PR TITLE
Reply queue should not require acknowledgement in dotnet tutorial 6.

### DIFF
--- a/dotnet/RPCClient.cs
+++ b/dotnet/RPCClient.cs
@@ -15,7 +15,7 @@ class RPCClient {
         channel = connection.CreateModel();
         replyQueueName = channel.QueueDeclare();
         consumer = new QueueingBasicConsumer(channel);
-        channel.BasicConsume(replyQueueName, false, consumer);
+        channel.BasicConsume(replyQueueName, true, consumer);
     }
 
     public string Call(string message) {


### PR DESCRIPTION
Unless I have misunderstood something - I think the call to BasicConsume for the reply queue should pass 'true' instead of 'false' for the 'noAck' parameter - as the callback messages are not acknowledged. Otherwise this leaves unacknowledged messages in the queue.
