### PR TITLE
Go: Added missing import "os"

### DIFF
--- a/go/new_task.go
+++ b/go/new_task.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/streadway/amqp"


### PR DESCRIPTION
Added missing `import "os"` for Go tutorial.
