### PR TITLE
Go: Changed receive_logs_direct.go to continue listening.

### DIFF
--- a/go/receive_logs_direct.go
+++ b/go/receive_logs_direct.go
@@ -67,18 +67,14 @@ func main() {
 	)
 	failOnError(err, "Failed to register a consumer")
 
-	done := make(chan bool)
+	forever := make(chan bool)
 
 	go func() {
 		for d := range msgs {
 			log.Printf(" [x] %s", d.Body)
-
-			done <- true
 		}
 	}()
 
 	log.Printf(" [*] Waiting for logs. To exit press CTRL+C")
-
-	<-done
-	log.Printf("Done")
+	<-forever
 }


### PR DESCRIPTION
Changed `receive_logs_direct.go` of Go tutorial to continue listening after the first message, to be consistent with other files including `receive_logs_topic.go`.
