### PR TITLE
nodejs: Fixed wrong connection.publish routingKey

### DIFF
--- a/javascript-nodejs/send.js
+++ b/javascript-nodejs/send.js
@@ -4,7 +4,7 @@ var amqp_hacks = require('./amqp-hacks');
 var connection = amqp.createConnection({host: 'localhost'});
 
 connection.on('ready', function(){
-    connection.publish('hello', 'Hello World!');
+    connection.publish('task_queue', 'Hello World!');
     console.log(" [x] Sent 'Hello World!'");
 
     amqp_hacks.safeEndConnection(connection);


### PR DESCRIPTION
In worker.js we are creating a queue called 'task_queue' so in send.js we should publish to 'task_queue' not to 'hello'.
