### PR TITLE
added dot count for fake work delay

### DIFF
--- a/go/worker.go
+++ b/go/worker.go
@@ -57,6 +57,9 @@ func main() {
 		for d := range msgs {
 			log.Printf("Received a message: %s", d.Body)
 			d.Ack(false)
+			dot_count := bytes.Count(d.Body, []byte("."))
+			t := time.Duration(dot_count)
+			time.Sleep(t * time.Second)
 		}
 	}()
 


### PR DESCRIPTION
The second RabbitMQ tutorial demonstrates multiple workers taking new tasks. This pull requests inserts the dot count used to sleep to simulate the work being done. Then as the tutorial shows, you can add dots to the message to make the workers take more time and see the effects on how work is picked up by the worker processes.
