### PR TITLE
Update ReceiveLogsDirect.java

### DIFF
--- a/java/ReceiveLogsDirect.java
+++ b/java/ReceiveLogsDirect.java
@@ -22,10 +22,6 @@ public class ReceiveLogsDirect {
       System.exit(1);
     }
     
-    for(String severity : argv){    
-      channel.queueBind(queueName, EXCHANGE_NAME, severity);
-    }
-    
     System.out.println(" [*] Waiting for messages. To exit press CTRL+C");
 
     QueueingConsumer consumer = new QueueingConsumer(channel);


### PR DESCRIPTION
for(String severity : argv){    
      channel.queueBind(queueName, EXCHANGE_NAME, severity);
    }
i delete these three lines in ReceiveLogsDirect.java.
i think it should be in EmitLogDirect.java not in ReceiveLogsDirect ,as we all know the consumer just need the queues,so the blinding should be in producer's class .