### PR TITLE
Provided an example for priority queue implementation in nodejs.

### DIFF
--- a/javascript-nodejs/src/receive_priority_queue.js
+++ b/javascript-nodejs/src/receive_priority_queue.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+var amqp = require('amqplib/callback_api');
+
+amqp.connect('amqp://localhost', function(err, conn) {
+  conn.createChannel(function(err, ch) {
+    var q = 'hello';
+
+    ch.assertQueue(q, {durable: false, maxPriority: 10});
+    console.log(" [*] Waiting for messages in %s. To exit press CTRL+C", q);
+    ch.consume(q, function(msg) {
+      console.log(" [x] Received %s", msg.content.toString());
+    }, {noAck: true});
+  });
+});

--- a/javascript-nodejs/src/send_priority_queue.js
+++ b/javascript-nodejs/src/send_priority_queue.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+var amqp = require('amqplib/callback_api');
+
+amqp.connect('amqp://localhost', function(err, conn) {
+  conn.createChannel(function(err, ch) {
+    var q = 'hello';
+
+    ch.assertQueue(q, {durable: false, maxPriority: 10});
+    for(var index=1; index<=50; index++) {
+        priorityValue = Math.floor((Math.random() * 10));
+        // index refers to message number. Lower is the index value, earlier is the message pushed into the queue.
+        message = 'Message index = ' + index + ' and Priority Value = ' + priorityValue;
+        ch.sendToQueue(q, new Buffer(message), {priority: priorityValue});
+        console.log(" [x] Sent '%s'", message);
+    }
+  });
+  setTimeout(function() { conn.close(); process.exit(0) }, 500);
+});


### PR DESCRIPTION
RabbitMQ has priority queue implementation in the core as of version 3.5.0. We can declare priority queues using the x-max-priority argument. This argument should be an integer indicating the maximum priority the queue should support. I will be happy to make some contributions on priority queue implementation tutorial using rabbitmq for all client's.

I have observed RabbitMq tutorials for different client's are quite consistent i.e., exactly same tutorials are available for all client's. Updating/adding tutorial of one of the client possibly requires porting the exact same tutorial for all other client's

Therefore, I would be happy to issue following PR's step wise as follow-up commits:

1. Porting the same tutorial for all [RabbitMq clients](https://github.com/rabbitmq/rabbitmq-tutorials) with a separate PR for each client in step-wise order.

2. If feasible and applicable, porting the tutorial demonstration over official [RabbitMq website](https://www.rabbitmq.com/getstarted.html) in step-wise order for supported client's as such the [website source](https://github.com/rabbitmq/rabbitmq-website/) is open.

Please correct me if above idea(s) doesn't really make sense or is not that important to have it in tutorials or is(are) not applicable.