### PR TITLE
Fix Python scripts for Python 3 compatibility.

### DIFF
--- a/python/emit_log.py
+++ b/python/emit_log.py
@@ -13,5 +13,5 @@ message = ' '.join(sys.argv[1:]) or "info: Hello World!"
 channel.basic_publish(exchange='logs',
                       routing_key='',
                       body=message)
-print " [x] Sent %r" % (message,)
+print(" [x] Sent %r" % message)
 connection.close()

--- a/python/emit_log_direct.py
+++ b/python/emit_log_direct.py
@@ -14,5 +14,5 @@ message = ' '.join(sys.argv[2:]) or 'Hello World!'
 channel.basic_publish(exchange='direct_logs',
                       routing_key=severity,
                       body=message)
-print " [x] Sent %r:%r" % (severity, message)
+print(" [x] Sent %r:%r" % (severity, message))
 connection.close()

--- a/python/emit_log_topic.py
+++ b/python/emit_log_topic.py
@@ -14,5 +14,5 @@ message = ' '.join(sys.argv[2:]) or 'Hello World!'
 channel.basic_publish(exchange='topic_logs',
                       routing_key=routing_key,
                       body=message)
-print " [x] Sent %r:%r" % (routing_key, message)
+print(" [x] Sent %r:%r" % (routing_key, message))
 connection.close()

--- a/python/new_task.py
+++ b/python/new_task.py
@@ -15,5 +15,5 @@ channel.basic_publish(exchange='',
                       properties=pika.BasicProperties(
                          delivery_mode = 2, # make message persistent
                       ))
-print " [x] Sent %r" % (message,)
+print(" [x] Sent %r" % message)
 connection.close()

--- a/python/receive.py
+++ b/python/receive.py
@@ -8,10 +8,10 @@ channel = connection.channel()
 
 channel.queue_declare(queue='hello')
 
-print ' [*] Waiting for messages. To exit press CTRL+C'
+print(' [*] Waiting for messages. To exit press CTRL+C')
 
 def callback(ch, method, properties, body):
-    print " [x] Received %r" % (body,)
+    print(" [x] Received %r" % body)
 
 channel.basic_consume(callback,
                       queue='hello',

--- a/python/receive_logs.py
+++ b/python/receive_logs.py
@@ -14,10 +14,10 @@ queue_name = result.method.queue
 channel.queue_bind(exchange='logs',
                    queue=queue_name)
 
-print ' [*] Waiting for logs. To exit press CTRL+C'
+print(' [*] Waiting for logs. To exit press CTRL+C')
 
 def callback(ch, method, properties, body):
-    print " [x] %r" % (body,)
+    print(" [x] %r" % body)
 
 channel.basic_consume(callback,
                       queue=queue_name,

--- a/python/receive_logs_direct.py
+++ b/python/receive_logs_direct.py
@@ -14,7 +14,7 @@ queue_name = result.method.queue
 
 severities = sys.argv[1:]
 if not severities:
-    print >> sys.stderr, "Usage: %s [info] [warning] [error]" % (sys.argv[0],)
+    sys.stderr.write("Usage: %s [info] [warning] [error]\n" % sys.argv[0])
     sys.exit(1)
 
 for severity in severities:
@@ -22,10 +22,10 @@ for severity in severities:
                        queue=queue_name,
                        routing_key=severity)
 
-print ' [*] Waiting for logs. To exit press CTRL+C'
+print(' [*] Waiting for logs. To exit press CTRL+C')
 
 def callback(ch, method, properties, body):
-    print " [x] %r:%r" % (method.routing_key, body,)
+    print(" [x] %r:%r" % (method.routing_key, body))
 
 channel.basic_consume(callback,
                       queue=queue_name,

--- a/python/receive_logs_topic.py
+++ b/python/receive_logs_topic.py
@@ -14,7 +14,7 @@ queue_name = result.method.queue
 
 binding_keys = sys.argv[1:]
 if not binding_keys:
-    print >> sys.stderr, "Usage: %s [binding_key]..." % (sys.argv[0],)
+    sys.stderr.write("Usage: %s [binding_key]...\n" % sys.argv[0])
     sys.exit(1)
 
 for binding_key in binding_keys:
@@ -22,10 +22,10 @@ for binding_key in binding_keys:
                        queue=queue_name,
                        routing_key=binding_key)
 
-print ' [*] Waiting for logs. To exit press CTRL+C'
+print(' [*] Waiting for logs. To exit press CTRL+C')
 
 def callback(ch, method, properties, body):
-    print " [x] %r:%r" % (method.routing_key, body,)
+    print(" [x] %r:%r" % (method.routing_key, body))
 
 channel.basic_consume(callback,
                       queue=queue_name,

--- a/python/rpc_client.py
+++ b/python/rpc_client.py
@@ -35,6 +35,6 @@ class FibonacciRpcClient(object):
 
 fibonacci_rpc = FibonacciRpcClient()
 
-print " [x] Requesting fib(30)"
+print(" [x] Requesting fib(30)")
 response = fibonacci_rpc.call(30)
-print " [.] Got %r" % (response,)
+print(" [.] Got %r" % response)

--- a/python/rpc_server.py
+++ b/python/rpc_server.py
@@ -19,7 +19,7 @@ def fib(n):
 def on_request(ch, method, props, body):
     n = int(body)
 
-    print " [.] fib(%s)"  % (n,)
+    print(" [.] fib(%s)" % n)
     response = fib(n)
 
     ch.basic_publish(exchange='',
@@ -32,5 +32,5 @@ def on_request(ch, method, props, body):
 channel.basic_qos(prefetch_count=1)
 channel.basic_consume(on_request, queue='rpc_queue')
 
-print " [x] Awaiting RPC requests"
+print(" [x] Awaiting RPC requests")
 channel.start_consuming()

--- a/python/send.py
+++ b/python/send.py
@@ -11,5 +11,5 @@ channel.queue_declare(queue='hello')
 channel.basic_publish(exchange='',
                       routing_key='hello',
                       body='Hello World!')
-print " [x] Sent 'Hello World!'"
+print(" [x] Sent 'Hello World!'")
 connection.close()

--- a/python/worker.py
+++ b/python/worker.py
@@ -7,12 +7,12 @@ connection = pika.BlockingConnection(pika.ConnectionParameters(
 channel = connection.channel()
 
 channel.queue_declare(queue='task_queue', durable=True)
-print ' [*] Waiting for messages. To exit press CTRL+C'
+print(' [*] Waiting for messages. To exit press CTRL+C')
 
 def callback(ch, method, properties, body):
-    print " [x] Received %r" % (body,)
-    time.sleep( body.count('.') )
-    print " [x] Done"
+    print(" [x] Received %r" % body)
+    time.sleep(body.count(b'.'))
+    print(" [x] Done")
     ch.basic_ack(delivery_tag = method.delivery_tag)
 
 channel.basic_qos(prefetch_count=1)


### PR DESCRIPTION
This makes the examples for the `pika` library compatible with Python 3 (tested each interaction on all of the scripts; the output is minimally different due to the fact that Python 3 will mark byte strings with a `b''`).

I didn't change anything for `puka` as it's limited to Python 2.6/2.7.