### PR TITLE
emit_log_topic.go: Removed unreachable panic()

### DIFF
--- a/go/emit_log_topic.go
+++ b/go/emit_log_topic.go
@@ -12,7 +12,6 @@ import (
 func failOnError(err error, msg string) {
 	if err != nil {
 		log.Fatalf("%s: %s", msg, err)
-		panic(fmt.Sprintf("%s: %s", msg, err))
 	}
 }
 


### PR DESCRIPTION
log.Fatalf() exist the program, so a following panic() is unnecessary