### PR TITLE
Use `Buffer.from` in place of `new Buffer`

### DIFF
--- a/javascript-nodejs/src/send.js
+++ b/javascript-nodejs/src/send.js
@@ -8,7 +8,7 @@ amqp.connect('amqp://localhost', function(err, conn) {
     var msg = 'Hello World!';
 
     ch.assertQueue(q, {durable: false});
-    ch.sendToQueue(q, new Buffer(msg));
+    ch.sendToQueue(q, Buffer.from(msg));
     console.log(" [x] Sent %s", msg);
   });
   setTimeout(function() { conn.close(); process.exit(0) }, 500);


### PR DESCRIPTION
Replace deprecated `new Buffer` instantiation brought up in [#230](https://github.com/rabbitmq/rabbitmq-website/issues/230). 