### PR TITLE
Correct emit_log_direct.py

### DIFF
--- a/python/emit_log_direct.py
+++ b/python/emit_log_direct.py
@@ -9,7 +9,7 @@ channel = connection.channel()
 channel.exchange_declare(exchange='direct_logs',
                          exchange_type='direct')
 
-severity = sys.argv[1] if len(sys.argv) > 1 else 'info'
+severity = sys.argv[1] if len(sys.argv) > 2 else 'info'
 message = ' '.join(sys.argv[2:]) or 'Hello World!'
 channel.basic_publish(exchange='direct_logs',
                       routing_key=severity,


### PR DESCRIPTION
Sys.argv will always be greater than 1, but in the instance
where the severity is supplied it would be greather than 2.

Closes rabbitmq/rabbitmq-tutorials#108