### PR TITLE
Correct emit_log_topic.py

### DIFF
--- a/python/emit_log_topic.py
+++ b/python/emit_log_topic.py
@@ -9,7 +9,7 @@ channel = connection.channel()
 channel.exchange_declare(exchange='topic_logs',
                          exchange_type='topic')
 
-routing_key = sys.argv[1] if len(sys.argv) > 1 else 'anonymous.info'
+routing_key = sys.argv[1] if len(sys.argv) > 2 else 'anonymous.info'
 message = ' '.join(sys.argv[2:]) or 'Hello World!'
 channel.basic_publish(exchange='topic_logs',
                       routing_key=routing_key,


### PR DESCRIPTION
Sys.argv will always be greater than 1, but in the instance
where the binding_key is supplied it would be greather than 2.

Closes rabbitmq/rabbitmq-tutorials#110