### PR TITLE
Use the BuiltinExchangeType instead of string literals in Java examples

### DIFF
--- a/java/EmitLog.java
+++ b/java/EmitLog.java
@@ -1,3 +1,4 @@
+import com.rabbitmq.client.BuiltinExchangeType;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.Channel;
@@ -12,7 +13,7 @@ public class EmitLog {
     Connection connection = factory.newConnection();
     Channel channel = connection.createChannel();
 
-    channel.exchangeDeclare(EXCHANGE_NAME, "fanout");
+    channel.exchangeDeclare(EXCHANGE_NAME, BuiltinExchangeType.FANOUT);
 
     String message = getMessage(argv);
 

--- a/java/EmitLogDirect.java
+++ b/java/EmitLogDirect.java
@@ -1,3 +1,4 @@
+import com.rabbitmq.client.BuiltinExchangeType;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.Channel;
@@ -13,7 +14,7 @@ public class EmitLogDirect {
     Connection connection = factory.newConnection();
     Channel channel = connection.createChannel();
 
-    channel.exchangeDeclare(EXCHANGE_NAME, "direct");
+    channel.exchangeDeclare(EXCHANGE_NAME, BuiltinExchangeType.DIRECT);
 
     String severity = getSeverity(argv);
     String message = getMessage(argv);

--- a/java/EmitLogHeader.java
+++ b/java/EmitLogHeader.java
@@ -38,7 +38,7 @@ public class EmitLogHeader {
     Connection connection = factory.newConnection();
     Channel channel = connection.createChannel();
 
-    channel.exchangeDeclare(EXCHANGE_NAME, "headers");
+    channel.exchangeDeclare(EXCHANGE_NAME, BuiltinExchangeType.HEADERS);
 
     AMQP.BasicProperties.Builder builder = new AMQP.BasicProperties.Builder();
 

--- a/java/EmitLogTopic.java
+++ b/java/EmitLogTopic.java
@@ -1,3 +1,4 @@
+import com.rabbitmq.client.BuiltinExchangeType;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.Channel;
@@ -16,7 +17,7 @@ public class EmitLogTopic {
       connection = factory.newConnection();
       channel = connection.createChannel();
 
-      channel.exchangeDeclare(EXCHANGE_NAME, "topic");
+      channel.exchangeDeclare(EXCHANGE_NAME, BuiltinExchangeType.TOPIC);
 
       String routingKey = getRouting(argv);
       String message = getMessage(argv);

--- a/java/ReceiveLogHeader.java
+++ b/java/ReceiveLogHeader.java
@@ -18,7 +18,7 @@ public class ReceiveLogHeader {
     Connection connection = factory.newConnection();
     Channel channel = connection.createChannel();
 
-    channel.exchangeDeclare(EXCHANGE_NAME, "headers");
+    channel.exchangeDeclare(EXCHANGE_NAME, BuiltinExchangeType.HEADERS);
 
     // The API requires a routing key, but in fact if you are using a header exchange the
     // value of the routing key is not used in the routing. You can receive information

--- a/java/ReceiveLogs.java
+++ b/java/ReceiveLogs.java
@@ -11,7 +11,7 @@ public class ReceiveLogs {
     Connection connection = factory.newConnection();
     Channel channel = connection.createChannel();
 
-    channel.exchangeDeclare(EXCHANGE_NAME, "fanout");
+    channel.exchangeDeclare(EXCHANGE_NAME, BuiltinExchangeType.FANOUT);
     String queueName = channel.queueDeclare().getQueue();
     channel.queueBind(queueName, EXCHANGE_NAME, "");
 

--- a/java/ReceiveLogsDirect.java
+++ b/java/ReceiveLogsDirect.java
@@ -12,7 +12,7 @@ public class ReceiveLogsDirect {
     Connection connection = factory.newConnection();
     Channel channel = connection.createChannel();
 
-    channel.exchangeDeclare(EXCHANGE_NAME, "direct");
+    channel.exchangeDeclare(EXCHANGE_NAME, BuiltinExchangeType.DIRECT);
     String queueName = channel.queueDeclare().getQueue();
 
     if (argv.length < 1){

--- a/java/ReceiveLogsTopic.java
+++ b/java/ReceiveLogsTopic.java
@@ -12,7 +12,7 @@ public class ReceiveLogsTopic {
     Connection connection = factory.newConnection();
     Channel channel = connection.createChannel();
 
-    channel.exchangeDeclare(EXCHANGE_NAME, "topic");
+    channel.exchangeDeclare(EXCHANGE_NAME, BuiltinExchangeType.TOPIC);
     String queueName = channel.queueDeclare().getQueue();
 
     if (argv.length < 1) {


### PR DESCRIPTION
The Java examples use string literals such as `"direct"` or `"fanout"` instead of the enumeration `BuiltinExchangeType` provided by the RabbitMQ client library.