### PR TITLE
Update worker.go

### DIFF
--- a/go/worker.go
+++ b/go/worker.go
@@ -56,11 +56,11 @@ func main() {
 	go func() {
 		for d := range msgs {
 			log.Printf("Received a message: %s", d.Body)
-			d.Ack(false)
 			dot_count := bytes.Count(d.Body, []byte("."))
 			t := time.Duration(dot_count)
 			time.Sleep(t * time.Second)
 			log.Printf("Done")
+			d.Ack(false)
 		}
 	}()
 


### PR DESCRIPTION
fix: `Ack` operation should be an the end of loop.

How to reproduction the problem

```
go run worker.go
go run worker.go
```

then run :
```
go run new_task.go hello world.....
```
this message will be send to one of the worker, if normal, it wait 5 seconds in the worker, but we press Ctrl+C stop it before 5 seconds. the message will lost in current work, it should be send to another worker immediately, But it won't be like this.

after change move `ack`  to the end of loop, it works.

I'm wondering , whether this is a bug or not.

