### PR TITLE
Add Makefile for Java tutorials

### DIFF
--- a/java/EmitLogDirect.java
+++ b/java/EmitLogDirect.java
@@ -26,15 +26,17 @@ public class EmitLogDirect {
     connection.close();
   }
 
-  private static String getSeverity(String[] strings){
-    if (strings.length < 1)
-    	    return "info";
+  private static String getSeverity(String[] strings) {
+    if (strings.length < 2) {
+        return "info";
+    }
     return strings[0];
   }
 
-  private static String getMessage(String[] strings){
-    if (strings.length < 2)
-    	    return "Hello World!";
+  private static String getMessage(String[] strings) {
+    if (strings.length < 2) {
+        return "Hello World!";
+    }
     return joinStrings(strings, " ", 1);
   }
 
@@ -49,4 +51,3 @@ public class EmitLogDirect {
     return words.toString();
   }
 }
-

--- a/java/Makefile
+++ b/java/Makefile
@@ -1,0 +1,41 @@
+JAVAC := javac -Xlint -Werror
+JAVA_RUN := java -cp $(CURDIR):amqp-client-4.1.1.jar:slf4j-api-1.7.21.jar:slf4j-simple-1.7.22.jar
+
+# http://www.rabbitmq.com/tutorials/tutorial-one-java.html
+# Tutorial One: Hello World
+tutorial_one: jars
+	$(JAVAC) -cp amqp-client-4.1.1.jar Send.java Recv.java
+
+run_tutorial_one: tutorial_one
+	$(JAVA_RUN) Send
+	$(JAVA_RUN) Recv
+
+# http://www.rabbitmq.com/tutorials/tutorial-two-java.html
+# Tutorial Two: Work Queues
+tutorial_two: jars
+	$(JAVAC) -cp amqp-client-4.1.1.jar NewTask.java Worker.java
+
+run_worker: tutorial_two
+	$(JAVA_RUN) Worker
+
+run_task: tutorial_two
+	$(JAVA_RUN) NewTask
+
+# http://www.rabbitmq.com/tutorials/tutorial-six-java.html
+# Tutorial Six: RPC
+tutorial_six: jars
+	$(JAVAC) -cp amqp-client-4.1.1.jar RPCClient.java RPCServer.java
+
+jars: amqp-client-4.1.1.jar slf4j-api-1.7.21.jar slf4j-simple-1.7.22.jar
+
+slf4j-api-1.7.21.jar:
+	curl -sLO http://central.maven.org/maven2/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar
+
+slf4j-simple-1.7.22.jar:
+	curl -sLO http://central.maven.org/maven2/org/slf4j/slf4j-simple/1.7.22/slf4j-simple-1.7.22.jar
+
+amqp-client-4.1.1.jar:
+	curl -sLO http://central.maven.org/maven2/com/rabbitmq/amqp-client/4.1.1/amqp-client-4.1.1.jar
+
+clean:
+	rm -f *.jar *.class

--- a/java/Makefile
+++ b/java/Makefile
@@ -15,16 +15,55 @@ run_tutorial_one: tutorial_one
 tutorial_two: jars
 	$(JAVAC) -cp amqp-client-4.1.1.jar NewTask.java Worker.java
 
-run_worker: tutorial_two
+run_tutorial_two_worker: tutorial_two
 	$(JAVA_RUN) Worker
 
-run_task: tutorial_two
+run_tutorial_two_task: tutorial_two
 	$(JAVA_RUN) NewTask
+
+# http://www.rabbitmq.com/tutorials/tutorial-three-java.html
+# Tutorial Three: Emit / Receive Logs
+tutorial_three: jars
+	$(JAVAC) -cp amqp-client-4.1.1.jar EmitLog.java ReceiveLogs.java
+
+run_tutorial_three_receive: tutorial_three
+	$(JAVA_RUN) ReceiveLogs
+
+run_tutorial_three_emit: tutorial_three
+	$(JAVA_RUN) EmitLog
+
+# http://www.rabbitmq.com/tutorials/tutorial-four-java.html
+# Tutorial Four: Routing
+tutorial_four: jars
+	$(JAVAC) -cp amqp-client-4.1.1.jar EmitLogDirect.java ReceiveLogsDirect.java
+
+run_tutorial_four_receive: tutorial_four
+	$(JAVA_RUN) ReceiveLogsDirect info warning error
+
+run_tutorial_four_emit: tutorial_four
+	$(JAVA_RUN) EmitLogDirect error "Run. Run. Or it will explode."
+
+# http://www.rabbitmq.com/tutorials/tutorial-five-java.html
+# Tutorial Five: Topics
+tutorial_five: jars
+	$(JAVAC) -cp amqp-client-4.1.1.jar EmitLogTopic.java ReceiveLogsTopic.java
+
+run_tutorial_five_receive: tutorial_five
+	$(JAVA_RUN) ReceiveLogsTopic 'kern.*'
+
+run_tutorial_five_emit: tutorial_five
+	$(JAVA_RUN) EmitLogTopic 'kern.critical' 'A critical kernel error'
 
 # http://www.rabbitmq.com/tutorials/tutorial-six-java.html
 # Tutorial Six: RPC
 tutorial_six: jars
 	$(JAVAC) -cp amqp-client-4.1.1.jar RPCClient.java RPCServer.java
+
+run_tutorial_six_client: tutorial_six
+	$(JAVA_RUN) RPCClient
+
+run_tutorial_six_server: tutorial_six
+	$(JAVA_RUN) RPCServer
 
 jars: amqp-client-4.1.1.jar slf4j-api-1.7.21.jar slf4j-simple-1.7.22.jar
 

--- a/java/Recv.java
+++ b/java/Recv.java
@@ -1,9 +1,14 @@
-import com.rabbitmq.client.*;
-
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Envelope;
 import java.io.IOException;
+import java.util.concurrent.TimeoutException;
 
 public class Recv {
-
   private final static String QUEUE_NAME = "hello";
 
   public static void main(String[] argv) throws Exception {
@@ -21,6 +26,17 @@ public class Recv {
           throws IOException {
         String message = new String(body, "UTF-8");
         System.out.println(" [x] Received '" + message + "'");
+        channel.basicCancel(consumerTag);
+      }
+
+      @Override
+      public void handleCancelOk(String consumerTag) {
+        try {
+          channel.close();
+          connection.close();
+        } catch (TimeoutException|IOException ex) {
+          ex.printStackTrace();
+        }
       }
     };
     channel.basicConsume(QUEUE_NAME, true, consumer);


### PR DESCRIPTION
This assists with fetching required `jar` files as well as running the examples.

Inspired by [this `rabbitmq-users` thread](https://groups.google.com/forum/#!starred/rabbitmq-users/OBMr60tQ0Yc)

Fixes #119 by using explicit imports in `Recv.java`