### PR TITLE
Replace QueueBasicConsumer

### DIFF
--- a/dotnet/RPCClient/RPCClient.cs
+++ b/dotnet/RPCClient/RPCClient.cs
@@ -11,7 +11,7 @@ class RPCClient
     private IConnection connection;
     private IModel channel;
     private string replyQueueName;
-    private QueueingBasicConsumer consumer;
+    private EventingBasicConsumer consumer;
 
     public RPCClient()
     {
@@ -19,29 +19,32 @@ class RPCClient
         connection = factory.CreateConnection();
         channel = connection.CreateModel();
         replyQueueName = channel.QueueDeclare().QueueName;
-        consumer = new QueueingBasicConsumer(channel);
+        consumer = new EventingBasicConsumer(channel);
         channel.BasicConsume(queue: replyQueueName, autoAck: true, consumer: consumer);
     }
 
-    public string Call(string message)
-    {
-        var corrId = Guid.NewGuid().ToString();
-        var props = channel.CreateBasicProperties();
-        props.ReplyTo = replyQueueName;
-        props.CorrelationId = corrId;
-
-        var messageBytes = Encoding.UTF8.GetBytes(message);
-        channel.BasicPublish(exchange: "", routingKey: "rpc_queue", basicProperties: props, body: messageBytes);
-
-        while(true)
+        public string Call(string message)
         {
-            var ea = (BasicDeliverEventArgs)consumer.Queue.Dequeue();
-            if(ea.BasicProperties.CorrelationId == corrId)
+            var corrId = Guid.NewGuid().ToString();
+            var props = channel.CreateBasicProperties();
+            string response = null;
+
+            props.ReplyTo = replyQueueName;
+            props.CorrelationId = corrId;
+
+            var messageBytes = Encoding.UTF8.GetBytes(message);
+            channel.BasicPublish(exchange: "", routingKey: "rpc_queue", basicProperties: props, body: messageBytes);
+
+            consumer.Received += (model, ea) =>
             {
-                return Encoding.UTF8.GetString(ea.Body);
-            }
+                if (ea.BasicProperties.CorrelationId == corrId)
+                {
+                    response = Encoding.UTF8.GetString(ea.Body);
+                }
+            };
+
+            return response;
         }
-    }
 
     public void Close()
     {


### PR DESCRIPTION
Replace QueueBasicConsumer  with EventingBasicConsumer.  

Refactor Call() based on EventingBasicConsumer. Queue.Dequeue no longer valid.