### PR TITLE
Update ruby tutorials

### DIFF
--- a/ruby/emit_log.rb
+++ b/ruby/emit_log.rb
@@ -1,17 +1,16 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
 
-require "bunny"
+require 'bunny'
 
-conn = Bunny.new(:automatically_recover => false)
-conn.start
+connection = Bunny.new
+connection.start
 
-ch   = conn.create_channel
-x    = ch.fanout("logs")
+channel = connection.create_channel
+exchange = channel.fanout('logs')
 
-msg  = ARGV.empty? ? "Hello World!" : ARGV.join(" ")
+message = ARGV.empty? ? 'Hello World!' : ARGV.join(' ')
 
-x.publish(msg)
-puts " [x] Sent #{msg}"
+exchange.publish(message)
+puts " [x] Sent #{message}"
 
-conn.close
+connection.close

--- a/ruby/emit_log_direct.rb
+++ b/ruby/emit_log_direct.rb
@@ -1,17 +1,15 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
+require 'bunny'
 
-require "bunny"
+connection = Bunny.new(automatically_recover: false)
+connection.start
 
-conn = Bunny.new(:automatically_recover => false)
-conn.start
+channel = connection.create_channel
+exchange = channel.direct('direct_logs')
+severity = ARGV.shift || 'info'
+message = ARGV.empty? ? 'Hello World!' : ARGV.join(' ')
 
-ch       = conn.create_channel
-x        = ch.direct("direct_logs")
-severity = ARGV.shift || "info"
-msg      = ARGV.empty? ? "Hello World!" : ARGV.join(" ")
+exchange.publish(message, routing_key: severity)
+puts " [x] Sent '#{message}'"
 
-x.publish(msg, :routing_key => severity)
-puts " [x] Sent '#{msg}'"
-
-conn.close
+connection.close

--- a/ruby/emit_log_topic.rb
+++ b/ruby/emit_log_topic.rb
@@ -1,17 +1,15 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
+require 'bunny'
 
-require "bunny"
+connection = Bunny.new(automatically_recover: false)
+connection.start
 
-conn = Bunny.new(:automatically_recover => false)
-conn.start
+channel = connection.create_channel
+exchange = channel.topic('topic_logs')
+severity = ARGV.shift || 'anonymous.info'
+message = ARGV.empty? ? 'Hello World!' : ARGV.join(' ')
 
-ch       = conn.create_channel
-x        = ch.topic("topic_logs")
-severity = ARGV.shift || "anonymous.info"
-msg      = ARGV.empty? ? "Hello World!" : ARGV.join(" ")
+exchange.publish(message, routing_key: severity)
+puts " [x] Sent #{severity}:#{message}"
 
-x.publish(msg, :routing_key => severity)
-puts " [x] Sent #{severity}:#{msg}"
-
-conn.close
+connection.close

--- a/ruby/new_task.rb
+++ b/ruby/new_task.rb
@@ -1,17 +1,15 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
+require 'bunny'
 
-require "bunny"
+connection = Bunny.new(automatically_recover: false)
+connection.start
 
-conn = Bunny.new(:automatically_recover => false)
-conn.start
+channel = connection.create_channel
+queue = channel.queue('task_queue', durable: true)
 
-ch   = conn.create_channel
-q    = ch.queue("task_queue", :durable => true)
+message = ARGV.empty? ? 'Hello World!' : ARGV.join(' ')
 
-msg  = ARGV.empty? ? "Hello World!" : ARGV.join(" ")
+queue.publish(message, persistent: true)
+puts " [x] Sent #{message}"
 
-q.publish(msg, :persistent => true)
-puts " [x] Sent #{msg}"
-
-conn.close
+connection.close

--- a/ruby/receive.rb
+++ b/ruby/receive.rb
@@ -1,21 +1,19 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
+require 'bunny'
 
-require "bunny"
+connection = Bunny.new(automatically_recover: false)
+connection.start
 
-conn = Bunny.new(:automatically_recover => false)
-conn.start
-
-ch   = conn.create_channel
-q    = ch.queue("hello")
+channel = connection.create_channel
+queue = channel.queue('hello')
 
 begin
-  puts " [*] Waiting for messages. To exit press CTRL+C"
-  q.subscribe(:block => true) do |delivery_info, properties, body|
+  puts ' [*] Waiting for messages. To exit press CTRL+C'
+  queue.subscribe(block: true) do |_delivery_info, _properties, body|
     puts " [x] Received #{body}"
   end
 rescue Interrupt => _
-  conn.close
+  connection.close
 
   exit(0)
 end

--- a/ruby/receive_logs.rb
+++ b/ruby/receive_logs.rb
@@ -1,26 +1,23 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
 
-require "bunny"
+require 'bunny'
 
-conn = Bunny.new(:automatically_recover => false)
-conn.start
+connection = Bunny.new
+connection.start
 
-ch  = conn.create_channel
-x   = ch.fanout("logs")
-q   = ch.queue("", :exclusive => true)
+channel = connection.create_channel
+exchange = channel.fanout('logs')
+queue = channel.queue('', exclusive: true)
 
-q.bind(x)
+queue.bind(exchange)
 
-puts " [*] Waiting for logs. To exit press CTRL+C"
+puts ' [*] Waiting for logs. To exit press CTRL+C'
 
 begin
-  q.subscribe(:block => true) do |delivery_info, properties, body|
+  queue.subscribe(block: true) do |_delivery_info, _properties, body|
     puts " [x] #{body}"
   end
 rescue Interrupt => _
-  ch.close
-  conn.close
-
-  exit(0)
+  channel.close
+  connection.close
 end

--- a/ruby/receive_logs_direct.rb
+++ b/ruby/receive_logs_direct.rb
@@ -1,32 +1,28 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
+require 'bunny'
 
-require "bunny"
+abort "Usage: #{$PROGRAM_NAME} [info] [warning] [error]" if ARGV.empty?
 
-if ARGV.empty?
-  abort "Usage: #{$0} [info] [warning] [error]"
-end
+connection = Bunny.new(automatically_recover: false)
+connection.start
 
-conn = Bunny.new(:automatically_recover => false)
-conn.start
-
-ch  = conn.create_channel
-x   = ch.direct("direct_logs")
-q   = ch.queue("", :exclusive => true)
+channel = connection.create_channel
+exchange = channel.direct('direct_logs')
+queue = channel.queue('', exclusive: true)
 
 ARGV.each do |severity|
-  q.bind(x, :routing_key => severity)
+  queue.bind(exchange, routing_key: severity)
 end
 
-puts " [*] Waiting for logs. To exit press CTRL+C"
+puts ' [*] Waiting for logs. To exit press CTRL+C'
 
 begin
-  q.subscribe(:block => true) do |delivery_info, properties, body|
+  queue.subscribe(block: true) do |delivery_info, _properties, body|
     puts " [x] #{delivery_info.routing_key}:#{body}"
   end
 rescue Interrupt => _
-  ch.close
-  conn.close
+  channel.close
+  connection.close
 
   exit(0)
 end

--- a/ruby/send.rb
+++ b/ruby/send.rb
@@ -1,15 +1,13 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
+require 'bunny'
 
-require "bunny"
+connection = Bunny.new(automatically_recover: false)
+connection.start
 
-conn = Bunny.new(:automatically_recover => false)
-conn.start
+channel = connection.create_channel
+queue = channel.queue('hello')
 
-ch   = conn.create_channel
-q    = ch.queue("hello")
-
-ch.default_exchange.publish("Hello World!", :routing_key => q.name)
+channel.default_exchange.publish('Hello World!', routing_key: queue.name)
 puts " [x] Sent 'Hello World!'"
 
-conn.close
+connection.close


### PR DESCRIPTION
Update the ruby tutorials with the 1.9+ syntax and variable names.

Basically linted with rubocop default configuration.

I made a refactor to the tutorial six (the RPC one) to be a little more clear the role of the instructions and their context. Please send some feedback on that

I will send the pull request on [rabbitmq-website](https://github.com/rabbitmq/rabbitmq-website) once this one is approved or merged.