### PR TITLE
Remove unnecessary to_i in worker.rb in ruby tutorials

### DIFF
--- a/ruby/worker.rb
+++ b/ruby/worker.rb
@@ -14,7 +14,7 @@ begin
   queue.subscribe(manual_ack: true, block: true) do |delivery_info, _properties, body|
     puts " [x] Received '#{body}'"
     # imitate some work
-    sleep body.count('.').to_i
+    sleep body.count('.')
     puts ' [x] Done'
     channel.ack(delivery_info.delivery_tag)
   end


### PR DESCRIPTION
Should be removed from the doc too: https://www.rabbitmq.com/tutorials/tutorial-two-ruby.html