### PR TITLE
Close the channel in GoLang if it can be possible

### DIFF
--- a/go/receive.go
+++ b/go/receive.go
@@ -48,6 +48,12 @@ func main() {
 		for d := range msgs {
 			log.Printf("Received a message: %s", d.Body)
 		}
+		Closing a channel has one more useful feature - reading operations on closed channels do not block and always return default value for a channel type
+        So Safe to close a Channel
+        Here the forever channel is only used to synchronize the execution but not for sending data.
+        As we close the channel in the goroutine the reading operation does not block and the main function continues to run.
+
+          close(forever)
 	}()
 
 	log.Printf(" [*] Waiting for messages. To exit press CTRL+C")


### PR DESCRIPTION
Closing a channel has one more useful feature - reading operations on closed channels do not block and always return default value for a channel type
So Safe to close a Channel
Here the forever channel is only used to synchronize the execution but not for sending data.
As we close the channel in the goroutine the reading operation does not block and the main function continues to run.

