### PR TITLE
removed queue object from sender…

### DIFF
--- a/ruby/send.rb
+++ b/ruby/send.rb
@@ -5,9 +5,10 @@ connection = Bunny.new(automatically_recover: false)
 connection.start
 
 channel = connection.create_channel
-queue = channel.queue('hello')
 
-channel.default_exchange.publish('Hello World!', routing_key: queue.name)
+# the default_exchange will route the message to a queue with the same name
+# as the routing_key, so it will end in the receiver's hello queue
+channel.default_exchange.publish('Hello World!', routing_key: 'hello')
 puts " [x] Sent 'Hello World!'"
 
 connection.close


### PR DESCRIPTION
…because he doesn't use a queue - instead he uses an exchange.

Hi, I'm new to RabbitMQ, but have a background of IBM Websphere MQ. So I had to learn the concept of exchanges and think they're obviously great for routing. This concept is described very well in amqpcloud's "Getting Started" ebook and in the amp 0-9-1 tutorial (https://www.rabbitmq.com/tutorials/amqp-concepts.html).

Everything's fine, so far - until you look into this example ruby code. Here the sender creates a queue. Why? Only to access its name (queue.name) a few lines later? I think this example is misleading.

In my case this example has lead me to think that in RabbitMQ the sender and the receiver need to agree on all aspects of the queue (not only its name), because as soon as I added a property (e.g. 'x-max-length-bytes') in sender.rb, the receiver.rb crashed with the following error message:
`PRECONDITION_FAILED - inequivalent arg 'x-max-length-bytes'`
So the solution is to add 'x-max-length-bytes' to receiver.rb as well? "Do I really have to keep the properties of the queue in sync between sender and receiver?" I asked in the rabbitmq slack channel - and guess what? The only guy who answered said "Yes!". What the hell? That would lead to tight coupling between sender and receiver! To bring this story to an end: this example not only leaded me to wrong assumptions about RabbitMQ, but also other people. The truth is: RabbitMQ does NOT lead to tight coupling between sender and receiver, because the sender does not interact with the receiver's queue.

So by removing the queue object from this example it will better match RabbitMQ's concepts and documentation. (I guess the same problem is in the examples for other programming languages.)

P.S.: The online tutorial (https://www.rabbitmq.com/tutorials/tutorial-one-ruby.html) features the same code as here, and it even lacks to show the exchanges in the little queue pictures completely. I suggest that you also change it there.