### PR TITLE
Update java RPCClient code to allow multiple RPC calls

### DIFF
--- a/java/RPCServer.java
+++ b/java/RPCServer.java
@@ -24,8 +24,9 @@ public class RPCServer {
     factory.setHost("localhost");
 
     Connection connection = null;
-    try {
-      connection      = factory.newConnection();
+    try
+    {
+      connection = factory.newConnection();
       final Channel channel = connection.createChannel();
 
       channel.queueDeclare(RPC_QUEUE_NAME, false, false, false, null);
@@ -57,9 +58,9 @@ public class RPCServer {
           finally {
             channel.basicPublish( "", properties.getReplyTo(), replyProps, response.getBytes("UTF-8"));
             channel.basicAck(envelope.getDeliveryTag(), false);
-            // RabbitMq consumer worker thread notifies the RPC server owner thread 
+            // RabbitMq consumer worker thread notifies the RPC server owner thread
             synchronized(this) {
-            	this.notify();
+              this.notify();
             }
           }
         }
@@ -68,13 +69,13 @@ public class RPCServer {
       channel.basicConsume(RPC_QUEUE_NAME, false, consumer);
       // Wait and be prepared to consume the message from RPC client.
       while (true) {
-      	synchronized(consumer) {
-      		try {
-      			consumer.wait();
-      	    } catch (InterruptedException e) {
-      	    	e.printStackTrace();	    	
-      	    }
-      	}
+        synchronized(consumer) {
+          try {
+              consumer.wait();
+            } catch (InterruptedException e) {
+              e.printStackTrace();
+            }
+        }
       }
     } catch (IOException | TimeoutException e) {
       e.printStackTrace();


### PR DESCRIPTION
Reported here: https://stackoverflow.com/q/51706696/1466825

Calling `channel.basicConsume` with a new consumer instance appears to use the old consumer. In this case, that consumer captured the *previous* value of `corrId` which means that subsequent RPC calls do not succeed as they use a new correlation ID.

This change only creates one consumer instance and updates the correlation ID value on every RPC call.