### PR TITLE
Use dedicated reply queue for RPC client

### DIFF
--- a/java/RPCClient.java
+++ b/java/RPCClient.java
@@ -63,9 +63,12 @@ public class RPCClient {
     try {
       fibonacciRpc = new RPCClient();
 
-      System.out.println(" [x] Requesting fib(30)");
-      response = fibonacciRpc.call("30");
-      System.out.println(" [.] Got '" + response + "'");
+      for (int i = 0; i < 32; i++) {
+        String i_str = Integer.toString(i);
+        System.out.println(" [x] Requesting fib(" + i_str + ")");
+        response = fibonacciRpc.call(i_str);
+        System.out.println(" [.] Got '" + response + "'");
+      }
     }
     catch  (IOException | TimeoutException | InterruptedException e) {
       e.printStackTrace();

--- a/java/RPCServer.java
+++ b/java/RPCServer.java
@@ -29,6 +29,7 @@ public class RPCServer {
       final Channel channel = connection.createChannel();
 
       channel.queueDeclare(RPC_QUEUE_NAME, false, false, false, null);
+      channel.queuePurge(RPC_QUEUE_NAME);
 
       channel.basicQos(1);
 


### PR DESCRIPTION
If different requests uses the same reply queue, the consumers can steal
responses from each other.

The reply consumer is cancelled after the response has arrived so the
reply queue can be auto-deleted.

References #174