### PR TITLE
Auto-ack for rpc-client in PHP

### DIFF
--- a/php/rpc_client.php
+++ b/php/rpc_client.php
@@ -32,7 +32,7 @@ class FibonacciRpcClient
             $this->callback_queue,
             '',
             false,
-            false,
+            true,
             false,
             false,
             array(


### PR DESCRIPTION
Auto-ack for rpc-client in PHP as for other tutorials in other languages.