### PR TITLE
Update Elixir dependency version: AMQP

### DIFF
--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -28,7 +28,7 @@ defmodule RabbitmqTutorials.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:amqp, "~> 1.0"},
+      {:amqp, "~> 1.1"},
     ]
   end
 end


### PR DESCRIPTION
I tried the Elixir examples on Elxir version `1.8.1`:

```
$ elixir --version
Erlang/OTP 21 [erts-10.2.4] [source] [64-bit] [smp:1:1] [ds:1:1:10] [async-threads:1] [hipe]

Elixir 1.8.1 (compiled with Erlang/OTP 21)
```

And I got some compilation errors. Updating `:amqp` version to `1.1.x` fixes them.

I'm not an expert on RabbitMQ nor Elixir, so I'm not sure if it's the best option and it fixes all possible issues. Let me know if this PR is ok.