### PR TITLE
Publish tasks as persistent messages in the php-amqp tutorial

### DIFF
--- a/php-amqp/new_task.php
+++ b/php-amqp/new_task.php
@@ -33,7 +33,7 @@ if(empty($message))
 	$message = "Hello World!";
 
 $exchange = new AMQPExchange($channel);
-$exchange->publish($message, $routing_key);
+$exchange->publish($message, $routing_key, AMQP_NOPARAM, array('delivery_mode' => 2));
 
 echo " [x] Sent {$message}", PHP_EOL;
 


### PR DESCRIPTION
This makes the tutorial consistent with other languages.