### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ The following ports are available:
  
 ## License
 
-Released under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+Released under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt).

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/RabbitAmqpTutorialsApplication.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/RabbitAmqpTutorialsApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/RabbitAmqpTutorialsRunner.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/RabbitAmqpTutorialsRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut1/Tut1Config.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut1/Tut1Config.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut1/Tut1Receiver.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut1/Tut1Receiver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut1/Tut1Sender.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut1/Tut1Sender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut2/Tut2Config.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut2/Tut2Config.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut2/Tut2Receiver.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut2/Tut2Receiver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut2/Tut2Sender.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut2/Tut2Sender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut3/Tut3Config.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut3/Tut3Config.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut3/Tut3Receiver.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut3/Tut3Receiver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut3/Tut3Sender.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut3/Tut3Sender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut4/Tut4Config.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut4/Tut4Config.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut4/Tut4Receiver.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut4/Tut4Receiver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut4/Tut4Sender.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut4/Tut4Sender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut5/Tut5Config.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut5/Tut5Config.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut5/Tut5Receiver.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut5/Tut5Receiver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut5/Tut5Sender.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut5/Tut5Sender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut6/Tut6Client.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut6/Tut6Client.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut6/Tut6Config.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut6/Tut6Config.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut6/Tut6Server.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut6/Tut6Server.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 21 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).