### PR TITLE
Avoid ArrayIndexOutOfBoundsException in EmitLogDirect

### DIFF
--- a/java/EmitLogDirect.java
+++ b/java/EmitLogDirect.java
@@ -37,7 +37,7 @@ public class EmitLogDirect {
     private static String joinStrings(String[] strings, String delimiter, int startIndex) {
         int length = strings.length;
         if (length == 0) return "";
-        if (length < startIndex) return "";
+        if (length <= startIndex) return "";
         StringBuilder words = new StringBuilder(strings[startIndex]);
         for (int i = startIndex + 1; i < length; i++) {
             words.append(delimiter).append(strings[i]);


### PR DESCRIPTION
It is true that the EmitLogDirect.getMessage() method only calls the
EmitLogDirect.joinStrings() method when the length of the strings array
argument is at least 2. However, it is safe make our method more robust
by avoiding the ArrayIndexOutOfBoundsException exception as much as we
can. Who knows? Maybe the EmitLogDirect.joinStrings() method could be
extracted in a utility class and used in cases where the startIndex
could potentially be equal to the length of the passed array.