### PR TITLE
update php tutorials: avoid usage of deprecated/internal stuff

### DIFF
--- a/php/receive.php
+++ b/php/receive.php
@@ -16,7 +16,7 @@ $callback = function ($msg) {
 
 $channel->basic_consume('hello', '', false, true, false, false, $callback);
 
-while (count($channel->callbacks)) {
+while ($channel->is_consuming()) {
     $channel->wait();
 }
 

--- a/php/receive_logs.php
+++ b/php/receive_logs.php
@@ -20,7 +20,7 @@ $callback = function ($msg) {
 
 $channel->basic_consume($queue_name, '', false, true, false, false, $callback);
 
-while (count($channel->callbacks)) {
+while ($channel->is_consuming()) {
     $channel->wait();
 }
 

--- a/php/receive_logs_direct.php
+++ b/php/receive_logs_direct.php
@@ -28,7 +28,7 @@ $callback = function ($msg) {
 
 $channel->basic_consume($queue_name, '', false, true, false, false, $callback);
 
-while (count($channel->callbacks)) {
+while ($channel->is_consuming()) {
     $channel->wait();
 }
 

--- a/php/receive_logs_topic.php
+++ b/php/receive_logs_topic.php
@@ -28,7 +28,7 @@ $callback = function ($msg) {
 
 $channel->basic_consume($queue_name, '', false, true, false, false, $callback);
 
-while (count($channel->callbacks)) {
+while ($channel->is_consuming()) {
     $channel->wait();
 }
 

--- a/php/rpc_server.php
+++ b/php/rpc_server.php
@@ -43,7 +43,7 @@ $callback = function ($req) {
 $channel->basic_qos(null, 1, null);
 $channel->basic_consume('rpc_queue', '', false, false, false, false, $callback);
 
-while (count($channel->callbacks)) {
+while ($channel->is_consuming()) {
     $channel->wait();
 }
 

--- a/php/worker.php
+++ b/php/worker.php
@@ -20,7 +20,7 @@ $callback = function ($msg) {
 $channel->basic_qos(null, 1, null);
 $channel->basic_consume('task_queue', '', false, false, false, false, $callback);
 
-while (count($channel->callbacks)) {
+while ($channel->is_consuming()) {
     $channel->wait();
 }
 


### PR DESCRIPTION
Update php examples according to https://github.com/php-amqplib/php-amqplib/commit/f30adba7ed6e296b98515d3ecd64f5814172d6f8
