### PR TITLE
Bug fix

### DIFF
--- a/python/emit_log_direct.py
+++ b/python/emit_log_direct.py
@@ -8,7 +8,7 @@ channel = connection.channel()
 
 channel.exchange_declare(exchange='direct_logs', exchange_type='direct')
 
-severity = sys.argv[1] if len(sys.argv) > 1 else 'info'
+severity = sys.argv[1] if len(sys.argv) > 2 else 'info'
 message = ' '.join(sys.argv[2:]) or 'Hello World!'
 channel.basic_publish(
     exchange='direct_logs', routing_key=severity, body=message)


### PR DESCRIPTION
The logic of tutorial which goes behind this line is "If you have more than 1 word to be sent, then mark the first as severity (the level of the log msg), and then everything else as the message itself". But with the current implementation, the first word always considered as severity even if no other words were given because `len(sys.argv) > 1` is true when at least one arg was given(then, the sys.argv contains the name of the file and the arg, and length=2)