### PR TITLE
Bootstrapping the pip installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ PVER=0.10.0
 python/.ok:
 	(cd python && \
 		virtualenv venv && \
-		./venv/bin/easy_install pip && \
+		./venv/bin/python -m ensurepip && \
 		./venv/bin/pip install pika==$(PVER) && \
 		touch .ok)
 clean::

--- a/python/README.md
+++ b/python/README.md
@@ -13,7 +13,7 @@ To run this code you need to install the `pika` package version `1.0.0` or later
 
 You may first need to run
 
-    easy_install pip
+    python -m ensurepip
 
 
 ## Code


### PR DESCRIPTION
Prefer to use ensurepip instead of the deprecated easy_install

https://docs.python.org/3/library/ensurepip.html
https://setuptools.readthedocs.io/en/latest/easy_install.html