### PR TITLE
Ensure to always use pip as a module of a given version of python

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -9,7 +9,7 @@ To successfully use the examples you will need a running RabbitMQ server.
 
 To run this code you need to install the `pika` package version `1.0.0` or later. To install it, run
 
-    pip install pika
+    python -m pip install pika
 
 You may first need to run
 


### PR DESCRIPTION
Prefer to use pip as a module, it's avoid error and mistakes during
package installation. With this approach we are always sure to
to install dependencies in the right python environment.