### PR TITLE
Revert "Bootstrapping the pip installer"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ PVER=0.10.0
 python/.ok:
 	(cd python && \
 		virtualenv venv && \
-		./venv/bin/python -m ensurepip && \
+		./venv/bin/easy_install pip && \
 		./venv/bin/pip install pika==$(PVER) && \
 		touch .ok)
 clean::

--- a/python/README.md
+++ b/python/README.md
@@ -13,7 +13,7 @@ To run this code you need to install the `pika` package version `1.0.0` or later
 
 You may first need to run
 
-    python -m ensurepip
+    easy_install pip
 
 
 ## Code


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-tutorials#232.

According to [this guide](https://docs.python.org/3/library/ensurepip.html), `ensurepip` ships with Python 3.4+. I think it's a good idea to keep the tutorials compatible with earlier versions.