### PR TITLE
feat: wait to make sure ReceiveLogs has started

### DIFF
--- a/dotnet-visual-studio/3_EmitLog/Program.cs
+++ b/dotnet-visual-studio/3_EmitLog/Program.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using RabbitMQ.Client;
 using System.Text;
+using System.Threading;
 
 class Program
 {
     public static void Main(string[] args)
     {
+        Thread.Sleep(2000);
         var factory = new ConnectionFactory() { HostName = "localhost" };
         using(var connection = factory.CreateConnection())
         using(var channel = connection.CreateModel())


### PR DESCRIPTION
When the "Startup Project" settings in Visual Studio are set as following the EmitLog program does a `BasicPublish` before ReceiveLogs even gets a chance to register interest.
This results in ReceiveLogs only displaying the text _Press [enter] to exit._.

![image](https://user-images.githubusercontent.com/1412705/62868568-40774800-bd16-11e9-9a71-4922323f1d5f.png)

Maybe this change is also relevant for the dotnet core tutorials if using [Compound launch configurations in Visual Studio Code](https://code.visualstudio.com/docs/editor/debugging#_compound-launch-configurations)

@pivotal-issuemaster This is an Obvious Fix