### PR TITLE
Java tutorial two: acknowledge only upon success

### DIFF
--- a/java/Worker.java
+++ b/java/Worker.java
@@ -22,12 +22,10 @@ public class Worker {
             String message = new String(delivery.getBody(), "UTF-8");
 
             System.out.println(" [x] Received '" + message + "'");
-            try {
-                doWork(message);
-            } finally {
-                System.out.println(" [x] Done");
-                channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
-            }
+            doWork(message);
+            // we never get past here if doWork raises an exception and this
+            // worker crashes. This way we only Ack if the work was done.
+            channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
         };
         channel.basicConsume(TASK_QUEUE_NAME, false, deliverCallback, consumerTag -> { });
     }


### PR DESCRIPTION
This would fix issue #254 by removing the try finally that caused the worker to acknowledge even if the `doWork` function ran into an exception as the finally branch of a try-finally is always run, even if an exception is raised in `doWork`.

Instead a comment is added explaining that an exception would cause the worker to crash and not ack