### PR TITLE
Use callback arg in Worker.cs

### DIFF
--- a/dotnet/Worker/Worker.cs
+++ b/dotnet/Worker/Worker.cs
@@ -30,7 +30,7 @@ class Worker
 
                 Console.WriteLine(" [x] Done");
 
-                channel.BasicAck(deliveryTag: ea.DeliveryTag, multiple: false);
+                model.BasicAck(deliveryTag: ea.DeliveryTag, multiple: false);
             };
             channel.BasicConsume(queue: "task_queue", autoAck: false, consumer: consumer);
 


### PR DESCRIPTION
When sending the ack, we should use the channel provided to us by the callback mechanism, not capture it from the outer scope. This lets use e.g. to extract the callback to a separate method.