### PR TITLE
Python Tutorial 1 - Handle KeyboardInterupt

### DIFF
--- a/python/receive.py
+++ b/python/receive.py
@@ -1,19 +1,26 @@
 #!/usr/bin/env python
-import pika
+import pika, sys, os
 
-connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
-channel = connection.channel()
+def main():
+    connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+    channel = connection.channel()
 
-channel.queue_declare(queue='hello')
+    channel.queue_declare(queue='hello')
 
+    def callback(ch, method, properties, body):
+        print(" [x] Received %r" % body)
 
-def callback(ch, method, properties, body):
-    print(" [x] Received %r" % body)
+    channel.basic_consume(queue='hello', on_message_callback=callback, auto_ack=True)
 
+    print(' [*] Waiting for messages. To exit press CTRL+C')
+    channel.start_consuming()
 
-channel.basic_consume(
-    queue='hello', on_message_callback=callback, auto_ack=True)
-
-print(' [*] Waiting for messages. To exit press CTRL+C')
-channel.start_consuming()
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('Interrupted')
+        try:
+            sys.exit(0)
+        except SystemExit:
+            os._exit(0)


### PR DESCRIPTION
Running the code and pressing Ctrl+C on Windows will result in:
```
(rabbitmq) C:\git\rabbitmq>python receive.py
 [*] Waiting for messages. To exit press CTRL+C
 [x] Received b'Hello World!'
 [x] Received b'Hello World!'
 [x] Received b'Hello World!'
Traceback (most recent call last):
  File "receive.py", line 15, in <module>
    channel.start_consuming()
  File "C:\Users\<username>\Envs\rabbitmq\lib\site-packages\pika\adapters\blocking_connection.py",
n start_consuming
    self._process_data_events(time_limit=None)
  File "C:\Users\<username>\Envs\rabbitmq\lib\site-packages\pika\adapters\blocking_connection.py",
n _process_data_events
    self.connection.process_data_events(time_limit=time_limit)
  File "C:\Users\<username>\Envs\rabbitmq\lib\site-packages\pika\adapters\blocking_connection.py",
 process_data_events
    self._flush_output(common_terminator)
  File "C:\Users\<username>\Envs\rabbitmq\lib\site-packages\pika\adapters\blocking_connection.py",
 _flush_output
    self._impl.ioloop.poll()
  File "C:\Users\<username>\Envs\rabbitmq\lib\site-packages\pika\adapters\select_connection.py", l
oll
    self._poller.poll()
  File "C:\Users\<username>\Envs\rabbitmq\lib\site-packages\pika\adapters\select_connection.py", l
oll
    read, write, error = select.select(
KeyboardInterrupt
^C
```

With the update, it shuts down cleanly:
```
(rabbitmq) C:\git\rabbitmq>python receive.py
 [*] Waiting for messages. To exit press CTRL+C
Interrupted
```

I know the tutorial should be minimal and have minimal error handling, but I think this should be added to avoid any potential confusion.

Goes together with https://github.com/rabbitmq/rabbitmq-website/pull/1042