### PR TITLE
Fix #288 - Upgrade dotnet-visual studio to .net50

### DIFF
--- a/dotnet-visual-studio/1_Receive/1_Receive.csproj
+++ b/dotnet-visual-studio/1_Receive/1_Receive.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.*" />
   </ItemGroup>
 </Project>

--- a/dotnet-visual-studio/1_Send/1_Send.csproj
+++ b/dotnet-visual-studio/1_Send/1_Send.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.*" />
   </ItemGroup>
 </Project>

--- a/dotnet-visual-studio/2_NewTask/2_NewTask.csproj
+++ b/dotnet-visual-studio/2_NewTask/2_NewTask.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.*" />
   </ItemGroup>
 </Project>

--- a/dotnet-visual-studio/2_Worker/2_Worker.csproj
+++ b/dotnet-visual-studio/2_Worker/2_Worker.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.*" />
   </ItemGroup>
 </Project>

--- a/dotnet-visual-studio/3_EmitLog/3_EmitLog.csproj
+++ b/dotnet-visual-studio/3_EmitLog/3_EmitLog.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.*" />
   </ItemGroup>
 </Project>

--- a/dotnet-visual-studio/3_ReceiveLogs/3_ReceiveLogs.csproj
+++ b/dotnet-visual-studio/3_ReceiveLogs/3_ReceiveLogs.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.*" />
   </ItemGroup>
 </Project>

--- a/dotnet-visual-studio/4_EmitLogDirect/4_EmitLogDirect.csproj
+++ b/dotnet-visual-studio/4_EmitLogDirect/4_EmitLogDirect.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.*" />
   </ItemGroup>
 </Project>

--- a/dotnet-visual-studio/4_ReceiveLogsDirect/4_ReceiveLogsDirect.csproj
+++ b/dotnet-visual-studio/4_ReceiveLogsDirect/4_ReceiveLogsDirect.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.*" />
   </ItemGroup>
 </Project>

--- a/dotnet-visual-studio/5_EmitLogTopic/5_EmitLogTopic.csproj
+++ b/dotnet-visual-studio/5_EmitLogTopic/5_EmitLogTopic.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.*" />
   </ItemGroup>
 </Project>

--- a/dotnet-visual-studio/5_ReceiveLogsTopic/5_ReceiveLogsTopic.csproj
+++ b/dotnet-visual-studio/5_ReceiveLogsTopic/5_ReceiveLogsTopic.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.*" />
   </ItemGroup>
 </Project>

--- a/dotnet-visual-studio/6_RPCClient/6_RPCClient.csproj
+++ b/dotnet-visual-studio/6_RPCClient/6_RPCClient.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.*" />
   </ItemGroup>
 </Project>

--- a/dotnet-visual-studio/6_RPCServer/6_RPCServer.csproj
+++ b/dotnet-visual-studio/6_RPCServer/6_RPCServer.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.*" />
   </ItemGroup>
 </Project>

--- a/dotnet-visual-studio/7_PublisherConfirms/7_PublisherConfirms.csproj
+++ b/dotnet-visual-studio/7_PublisherConfirms/7_PublisherConfirms.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Changes:
* Upgraded dotnet-visualstudio example to .net 5.0
* Upgraded RabbitMQ client to latest version including wildcard matching for patch version (6.2.*) so that examples are always pulling latest patch version on restore
