### PR TITLE
Add C# .NET 6.0 to List of languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following ports are available:
 
  * [C#](./dotnet)
  * [C# (with Visual Studio)](./dotnet-visual-studio)
+ * [C# (.NET 6.0)](./dotnet-6)
  * [Clojure](./clojure)
  * [Common Lisp](./common-lisp)
  * [Dart](./dart)


### PR DESCRIPTION
Update README to add C# .NET 6.0 to the list of languages