### PR TITLE
Go: Use log.Panicf instead log.Fatalf

### DIFF
--- a/go/emit_log.go
+++ b/go/emit_log.go
@@ -10,7 +10,7 @@ import (
 
 func failOnError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("%s: %s", msg, err)
+		log.Panicf("%s: %s", msg, err)
 	}
 }
 

--- a/go/emit_log_direct.go
+++ b/go/emit_log_direct.go
@@ -10,7 +10,7 @@ import (
 
 func failOnError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("%s: %s", msg, err)
+		log.Panicf("%s: %s", msg, err)
 	}
 }
 
@@ -38,8 +38,8 @@ func main() {
 	err = ch.Publish(
 		"logs_direct",         // exchange
 		severityFrom(os.Args), // routing key
-		false, // mandatory
-		false, // immediate
+		false,                 // mandatory
+		false,                 // immediate
 		amqp.Publishing{
 			ContentType: "text/plain",
 			Body:        []byte(body),

--- a/go/emit_log_topic.go
+++ b/go/emit_log_topic.go
@@ -10,7 +10,7 @@ import (
 
 func failOnError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("%s: %s", msg, err)
+		log.Panicf("%s: %s", msg, err)
 	}
 }
 
@@ -38,8 +38,8 @@ func main() {
 	err = ch.Publish(
 		"logs_topic",          // exchange
 		severityFrom(os.Args), // routing key
-		false, // mandatory
-		false, // immediate
+		false,                 // mandatory
+		false,                 // immediate
 		amqp.Publishing{
 			ContentType: "text/plain",
 			Body:        []byte(body),

--- a/go/new_task.go
+++ b/go/new_task.go
@@ -10,7 +10,7 @@ import (
 
 func failOnError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("%s: %s", msg, err)
+		log.Panicf("%s: %s", msg, err)
 	}
 }
 

--- a/go/publisher_confirms.go
+++ b/go/publisher_confirms.go
@@ -8,7 +8,7 @@ import (
 
 func failOnError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("%s: %s", msg, err)
+		log.Panicf("%s: %s", msg, err)
 	}
 }
 

--- a/go/receive.go
+++ b/go/receive.go
@@ -8,7 +8,7 @@ import (
 
 func failOnError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("%s: %s", msg, err)
+		log.Panicf("%s: %s", msg, err)
 	}
 }
 

--- a/go/receive_logs.go
+++ b/go/receive_logs.go
@@ -8,7 +8,7 @@ import (
 
 func failOnError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("%s: %s", msg, err)
+		log.Panicf("%s: %s", msg, err)
 	}
 }
 

--- a/go/receive_logs_direct.go
+++ b/go/receive_logs_direct.go
@@ -9,7 +9,7 @@ import (
 
 func failOnError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("%s: %s", msg, err)
+		log.Panicf("%s: %s", msg, err)
 	}
 }
 

--- a/go/receive_logs_topic.go
+++ b/go/receive_logs_topic.go
@@ -9,7 +9,7 @@ import (
 
 func failOnError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("%s: %s", msg, err)
+		log.Panicf("%s: %s", msg, err)
 	}
 }
 

--- a/go/rpc_client.go
+++ b/go/rpc_client.go
@@ -13,7 +13,7 @@ import (
 
 func failOnError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("%s: %s", msg, err)
+		log.Panicf("%s: %s", msg, err)
 	}
 }
 

--- a/go/rpc_server.go
+++ b/go/rpc_server.go
@@ -9,7 +9,7 @@ import (
 
 func failOnError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("%s: %s", msg, err)
+		log.Panicf("%s: %s", msg, err)
 	}
 }
 

--- a/go/send.go
+++ b/go/send.go
@@ -8,7 +8,7 @@ import (
 
 func failOnError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("%s: %s", msg, err)
+		log.Panicf("%s: %s", msg, err)
 	}
 }
 
@@ -42,5 +42,5 @@ func main() {
 			Body:        []byte(body),
 		})
 	failOnError(err, "Failed to publish a message")
-	log.Printf(" [x] Sent %s", body)
+	log.Printf(" [x] Sent %s\n", body)
 }

--- a/go/worker.go
+++ b/go/worker.go
@@ -10,7 +10,7 @@ import (
 
 func failOnError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("%s: %s", msg, err)
+		log.Panicf("%s: %s", msg, err)
 	}
 }
 


### PR DESCRIPTION
The problem is that log.Fatalf calls os.Exit(1) behind the covers and
defer statements won't be called.