### PR TITLE
Clarify `forever` channel declarations

### DIFF
--- a/go/publisher_confirms.go
+++ b/go/publisher_confirms.go
@@ -52,7 +52,7 @@ func main() {
 	publish(ch, q.Name, "hello")
 
 	log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
-	forever := make(chan bool)
+	var forever chan struct{}
 	<-forever
 }
 

--- a/go/receive.go
+++ b/go/receive.go
@@ -42,7 +42,7 @@ func main() {
 	)
 	failOnError(err, "Failed to register a consumer")
 
-	forever := make(chan bool)
+	var forever chan struct{}
 
 	go func() {
 		for d := range msgs {

--- a/go/receive_logs.go
+++ b/go/receive_logs.go
@@ -61,7 +61,7 @@ func main() {
 	)
 	failOnError(err, "Failed to register a consumer")
 
-	forever := make(chan bool)
+	var forever chan struct{}
 
 	go func() {
 		for d := range msgs {

--- a/go/receive_logs_direct.go
+++ b/go/receive_logs_direct.go
@@ -69,7 +69,7 @@ func main() {
 	)
 	failOnError(err, "Failed to register a consumer")
 
-	forever := make(chan bool)
+	var forever chan struct{}
 
 	go func() {
 		for d := range msgs {

--- a/go/receive_logs_topic.go
+++ b/go/receive_logs_topic.go
@@ -69,7 +69,7 @@ func main() {
 	)
 	failOnError(err, "Failed to register a consumer")
 
-	forever := make(chan bool)
+	var forever chan struct{}
 
 	go func() {
 		for d := range msgs {

--- a/go/rpc_server.go
+++ b/go/rpc_server.go
@@ -60,7 +60,7 @@ func main() {
 	)
 	failOnError(err, "Failed to register a consumer")
 
-	forever := make(chan bool)
+	var forever chan struct{}
 
 	go func() {
 		for d := range msgs {

--- a/go/worker.go
+++ b/go/worker.go
@@ -51,7 +51,7 @@ func main() {
 	)
 	failOnError(err, "Failed to register a consumer")
 
-	forever := make(chan bool)
+	var forever chan struct{}
 
 	go func() {
 		for d := range msgs {


### PR DESCRIPTION
The current idiom

    forever := make(chan bool)

gives the impression that booleans will be sent through `forever`.  But
the channel never has anything sent through it; its purpose is just to
block indefinitely.

This PR clarifies the idiom in two ways:

  * `bool` is replaced by `struct{}` – the unit type, as Go has no
    bottom type (empty type; ⊥) – clarifying that whatever may be sent
    through the channel will never carry any information.
  * The channel itself is replaced by `nil` – which always blocks when
    read from or written to (see below) – clarifying that nothing at all
    will ever be sent through it, leaving no doubts as to its purpose.

From [the specification](https://go.dev/ref/spec):

  * "A `nil` channel is never ready for communication."
  * "Receiving from a `nil` channel blocks forever."
  * "A send on a `nil` channel blocks forever."
