### PR TITLE
Update RPCClient.cs to fix problem: The client hangs during connection.Close(), if the channel was not closed.

### DIFF
--- a/dotnet/RPCClient/RPCClient.cs
+++ b/dotnet/RPCClient/RPCClient.cs
@@ -63,7 +63,8 @@ public class RpcClient
 
     public void Close()
     {
-        connection.Close();
+        channel.Close();
+        connection.Close();        
     }
 }
 


### PR DESCRIPTION
The client hangs during connection.Close(), if the channel was not closed. Closing the channel before the connection fixes this behavior.