### PR TITLE
short sleeps in response checker loop

### DIFF
--- a/python/rpc_client.py
+++ b/python/rpc_client.py
@@ -19,6 +19,9 @@ class FibonacciRpcClient(object):
             on_message_callback=self.on_response,
             auto_ack=True)
 
+        self.response = None
+        self.corr_id = None
+
     def on_response(self, ch, method, props, body):
         if self.corr_id == props.correlation_id:
             self.response = body
@@ -36,6 +39,7 @@ class FibonacciRpcClient(object):
             body=str(n))
         while self.response is None:
             self.connection.process_data_events()
+            self.connection.sleep(0.00001)
         return int(self.response)
 
 


### PR DESCRIPTION
"while self.response is None" is processing data events more than 10,000 times per second, and that causes 100% CPU usage.
If server wouldn't response, client CPU keeps using 100% CPU.