### PR TITLE
Python loop fix

### DIFF
--- a/python/rpc_client.py
+++ b/python/rpc_client.py
@@ -37,8 +37,7 @@ class FibonacciRpcClient(object):
                 correlation_id=self.corr_id,
             ),
             body=str(n))
-        while self.response is None:
-            self.connection.process_data_events(None)
+        self.connection.process_data_events(time_limit=None)
         return int(self.response)
 
 

--- a/python/rpc_client.py
+++ b/python/rpc_client.py
@@ -19,6 +19,9 @@ class FibonacciRpcClient(object):
             on_message_callback=self.on_response,
             auto_ack=True)
 
+        self.response = None
+        self.corr_id = None
+
     def on_response(self, ch, method, props, body):
         if self.corr_id == props.correlation_id:
             self.response = body
@@ -36,6 +39,7 @@ class FibonacciRpcClient(object):
             body=str(n))
         while self.response is None:
             self.connection.process_data_events()
+            self.connection.sleep(0.00001)
         return int(self.response)
 
 

--- a/python/rpc_client.py
+++ b/python/rpc_client.py
@@ -38,8 +38,7 @@ class FibonacciRpcClient(object):
             ),
             body=str(n))
         while self.response is None:
-            self.connection.process_data_events()
-            self.connection.sleep(0.00001)
+            self.connection.process_data_events(None)
         return int(self.response)
 
 


### PR DESCRIPTION
Calling `connection.process_data_events` uses 100% CPU until response is returned, and this makes problem if server does not response. Passing `None` to this function, blocks until I/O produces actionable events.