### PR TITLE
Simplified RPC examples

### DIFF
--- a/java/RPCServer.java
+++ b/java/RPCServer.java
@@ -14,53 +14,36 @@ public class RPCServer {
         ConnectionFactory factory = new ConnectionFactory();
         factory.setHost("localhost");
 
-        try (Connection connection = factory.newConnection();
-             Channel channel = connection.createChannel()) {
-            channel.queueDeclare(RPC_QUEUE_NAME, false, false, false, null);
-            channel.queuePurge(RPC_QUEUE_NAME);
+        Connection connection = factory.newConnection();
+        Channel channel = connection.createChannel();
+        channel.queueDeclare(RPC_QUEUE_NAME, false, false, false, null);
+        channel.queuePurge(RPC_QUEUE_NAME);
 
-            channel.basicQos(1);
+        channel.basicQos(1);
 
-            System.out.println(" [x] Awaiting RPC requests");
+        System.out.println(" [x] Awaiting RPC requests");
 
-            Object monitor = new Object();
-            DeliverCallback deliverCallback = (consumerTag, delivery) -> {
-                AMQP.BasicProperties replyProps = new AMQP.BasicProperties
-                        .Builder()
-                        .correlationId(delivery.getProperties().getCorrelationId())
-                        .build();
+        DeliverCallback deliverCallback = (consumerTag, delivery) -> {
+            AMQP.BasicProperties replyProps = new AMQP.BasicProperties
+                    .Builder()
+                    .correlationId(delivery.getProperties().getCorrelationId())
+                    .build();
 
-                String response = "";
+            String response = "";
+            try {
+                String message = new String(delivery.getBody(), "UTF-8");
+                int n = Integer.parseInt(message);
 
-                try {
-                    String message = new String(delivery.getBody(), "UTF-8");
-                    int n = Integer.parseInt(message);
-
-                    System.out.println(" [.] fib(" + message + ")");
-                    response += fib(n);
-                } catch (RuntimeException e) {
-                    System.out.println(" [.] " + e.toString());
-                } finally {
-                    channel.basicPublish("", delivery.getProperties().getReplyTo(), replyProps, response.getBytes("UTF-8"));
-                    channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
-                    // RabbitMq consumer worker thread notifies the RPC server owner thread
-                    synchronized (monitor) {
-                        monitor.notify();
-                    }
-                }
-            };
-
-            channel.basicConsume(RPC_QUEUE_NAME, false, deliverCallback, (consumerTag -> { }));
-            // Wait and be prepared to consume the message from RPC client.
-            while (true) {
-                synchronized (monitor) {
-                    try {
-                        monitor.wait();
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                }
+                System.out.println(" [.] fib(" + message + ")");
+                response += fib(n);
+            } catch (RuntimeException e) {
+                System.out.println(" [.] " + e);
+            } finally {
+                channel.basicPublish("", delivery.getProperties().getReplyTo(), replyProps, response.getBytes("UTF-8"));
+                channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
             }
-        }
+        };
+
+        channel.basicConsume(RPC_QUEUE_NAME, false, deliverCallback, (consumerTag -> {}));
     }
 }


### PR DESCRIPTION
Hi,

I simplified the RPC example:
- Client: Use CompletableFuture instead of BlockingQueue of size one. I thought the blocking queue was confusing in this case. You only want to return one result. Why not use the data structure available for that purpose?
- Server: Just do not close the connection and channel. That makes sure the server does not stop. The notify() and wait() do not add any value to the demo. This is the same solution as explained in tutorial one.

Please note that the website also needs an update when accepting this change. Let me know if you like this pull request and would like a pull request for an update on rabbitmq-website as well.

With kind regards,