### PR TITLE
Added C++ code examplesfor all tutorials

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,40 @@
+set(CMAKE_CXX_STANDARD 11)
+
+add_executable(send send.cpp)
+target_link_libraries(send rabbitmq)
+
+add_executable(receive receive.cpp)
+target_link_libraries(receive rabbitmq)
+
+add_executable(new_task new_task.cpp)
+target_link_libraries(new_task rabbitmq)
+
+add_executable(worker worker.cpp)
+target_link_libraries(worker rabbitmq)
+
+add_executable(emit_log emit_log.cpp)
+target_link_libraries(emit_log rabbitmq)
+
+add_executable(receive_logs receive_logs.cpp)
+target_link_libraries(receive_logs rabbitmq)
+
+add_executable(emit_log_direct emit_log_direct.cpp)
+target_link_libraries(emit_log_direct rabbitmq)
+
+add_executable(receive_logs_direct receive_logs_direct.cpp)
+target_link_libraries(receive_logs_direct rabbitmq)
+
+add_executable(emit_log_topic emit_log_topic.cpp)
+target_link_libraries(emit_log_topic rabbitmq)
+
+add_executable(receive_logs_topic receive_logs_topic.cpp)
+target_link_libraries(receive_logs_topic rabbitmq)
+
+add_executable(rpc_server rpc_server.cpp)
+target_link_libraries(rpc_server rabbitmq)
+
+add_executable(rpc_client rpc_client.cpp)
+target_link_libraries(rpc_client rabbitmq)
+
+add_executable(publisher_confirms publisher_confirms.cpp)
+target_link_libraries(publisher_confirms rabbitmq)

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,0 +1,11 @@
+# C++ code for RabbitMQ tutorials
+
+Here you can find the C++ code examples from [RabbitMQ
+tutorials](https://www.rabbitmq.com/getstarted.html).
+
+To successfully use the examples you will need a RabbitMQ node running locally.
+
+## Requirements
+Examples use [rabbitmq-c library](https://github.com/alanxz/rabbitmq-c)	that must be installed first.
+You can build the examples via CMakeFile.txt.
+Examples are tested on CentOS 7, RabbitMQ 3.10.0, Erlang 23.3.1 and built with Visual Studio Code 1.73.1 

--- a/cpp/emit_log.cpp
+++ b/cpp/emit_log.cpp
@@ -1,0 +1,37 @@
+#include <string.h>
+#include <iostream>
+#include <sstream>
+#include <iterator>
+
+#include <amqp.h>
+#include <amqp_tcp_socket.h>
+
+int main(int argc, char const *const *argv)
+{
+  amqp_connection_state_t conn = amqp_new_connection();
+  amqp_socket_t *socket = amqp_tcp_socket_new(conn);
+  amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+  amqp_login(conn, "/", 0, AMQP_DEFAULT_FRAME_SIZE, 0, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+  const amqp_channel_t KChannel = 1;
+  amqp_channel_open(conn, KChannel);
+
+  amqp_bytes_t exchangeName(amqp_cstring_bytes("logs"));
+  amqp_exchange_declare(conn, KChannel, exchangeName, amqp_cstring_bytes("fanout"), 
+                        false, false, false, false, amqp_empty_table);
+
+  std::string message("info: Hello World!");
+  if (argc > 1)
+  {
+    std::stringstream s;
+    copy(&argv[1], &argv[argc], std::ostream_iterator<const char*>(s, " "));
+    message = s.str();
+  }
+
+  amqp_basic_publish(conn, KChannel, exchangeName, amqp_empty_bytes, false, false, nullptr, amqp_cstring_bytes(message.c_str()));
+  std::cout << " [x] Sent " << message << std::endl;
+
+  amqp_channel_close(conn, KChannel, AMQP_REPLY_SUCCESS);
+  amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
+  amqp_destroy_connection(conn);
+  return 0;
+}

--- a/cpp/emit_log_direct.cpp
+++ b/cpp/emit_log_direct.cpp
@@ -1,0 +1,38 @@
+#include <string.h>
+#include <iostream>
+#include <sstream>
+#include <iterator>
+
+#include <amqp.h>
+#include <amqp_tcp_socket.h>
+
+int main(int argc, char const *const *argv)
+{
+  amqp_connection_state_t conn = amqp_new_connection();
+  amqp_socket_t *socket = amqp_tcp_socket_new(conn);
+  amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+  amqp_login(conn, "/", 0, AMQP_DEFAULT_FRAME_SIZE, 0, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+  const amqp_channel_t KChannel = 1;
+  amqp_channel_open(conn, KChannel);
+
+  amqp_bytes_t exchangeName(amqp_cstring_bytes("direct_logs"));
+  amqp_exchange_declare(conn, KChannel, exchangeName, amqp_cstring_bytes("direct"), 
+                        false, false, false, false, amqp_empty_table);
+
+  std::string severity = argc > 1 ? argv[1] : "info";
+  std::string message(" Hello World!");
+  if (argc > 2)
+  {
+    std::stringstream s;
+    copy(&argv[2], &argv[argc], std::ostream_iterator<const char*>(s, " "));
+    message = s.str();
+  }
+
+  amqp_basic_publish(conn, KChannel, exchangeName, amqp_cstring_bytes(severity.c_str()), false, false, nullptr, amqp_cstring_bytes(message.c_str()));
+  std::cout << " [x] Sent " << severity << ":" << message << std::endl;
+
+  amqp_channel_close(conn, KChannel, AMQP_REPLY_SUCCESS);
+  amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
+  amqp_destroy_connection(conn);
+  return 0;
+}

--- a/cpp/emit_log_topic.cpp
+++ b/cpp/emit_log_topic.cpp
@@ -1,0 +1,38 @@
+#include <string.h>
+#include <iostream>
+#include <sstream>
+#include <iterator>
+
+#include <amqp.h>
+#include <amqp_tcp_socket.h>
+
+int main(int argc, char const *const *argv)
+{
+  amqp_connection_state_t conn = amqp_new_connection();
+  amqp_socket_t *socket = amqp_tcp_socket_new(conn);
+  amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+  amqp_login(conn, "/", 0, AMQP_DEFAULT_FRAME_SIZE, 0, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+  const amqp_channel_t KChannel = 1;
+  amqp_channel_open(conn, KChannel);
+
+  amqp_bytes_t exchangeName(amqp_cstring_bytes("topic_logs"));
+  amqp_exchange_declare(conn, KChannel, exchangeName, amqp_cstring_bytes("topic"), 
+                        false, false, false, false, amqp_empty_table);
+
+  std::string routing_key = argc > 2 ? argv[1] : "anonymous.info";
+  std::string message(" Hello World!");
+  if (argc > 2)
+  {
+    std::stringstream s;
+    copy(&argv[2], &argv[argc], std::ostream_iterator<const char*>(s, " "));
+    message = s.str();
+  }
+
+  amqp_basic_publish(conn, KChannel, exchangeName, amqp_cstring_bytes(routing_key.c_str()), false, false, nullptr, amqp_cstring_bytes(message.c_str()));
+  std::cout << " [x] Sent " << routing_key << ":" << message << std::endl;
+
+  amqp_channel_close(conn, KChannel, AMQP_REPLY_SUCCESS);
+  amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
+  amqp_destroy_connection(conn);
+  return 0;
+}

--- a/cpp/new_task.cpp
+++ b/cpp/new_task.cpp
@@ -1,0 +1,40 @@
+#include <string.h>
+#include <iostream>
+#include <sstream>
+#include <iterator>
+
+#include <amqp.h>
+#include <amqp_tcp_socket.h>
+
+int main(int argc, char const *const *argv)
+{
+  amqp_connection_state_t conn = amqp_new_connection();
+  amqp_socket_t *socket = amqp_tcp_socket_new(conn);
+  amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+  amqp_login(conn, "/", 0, AMQP_DEFAULT_FRAME_SIZE, 0, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+  const amqp_channel_t KChannel = 1;
+  amqp_channel_open(conn, KChannel);
+
+  amqp_bytes_t queueName(amqp_cstring_bytes("task_queue"));
+  amqp_queue_declare(conn, KChannel, queueName, false, /*durable*/ true, false, true, amqp_empty_table);
+
+  std::string message("Hello World!");
+  if (argc > 1)
+  {
+    std::stringstream s;
+    copy(&argv[1], &argv[argc], std::ostream_iterator<const char*>(s, " "));
+    message = s.str();
+  }
+
+  amqp_basic_properties_t props;
+  props._flags = AMQP_BASIC_DELIVERY_MODE_FLAG;
+  props.delivery_mode = AMQP_DELIVERY_PERSISTENT;
+
+  amqp_basic_publish(conn, KChannel, amqp_empty_bytes, /* routing key*/ queueName, false, false, &props, amqp_cstring_bytes(message.c_str()));
+  std::cout << " [x] Sent " << message << std::endl;
+
+  amqp_channel_close(conn, KChannel, AMQP_REPLY_SUCCESS);
+  amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
+  amqp_destroy_connection(conn);
+  return 0;
+}

--- a/cpp/publisher_confirms.cpp
+++ b/cpp/publisher_confirms.cpp
@@ -1,0 +1,52 @@
+#include <string.h>
+#include <iostream>
+
+#include <amqp.h>
+#include <amqp_tcp_socket.h>
+
+int main(int argc, char const *const *argv)
+{
+    amqp_connection_state_t conn = amqp_new_connection();
+    amqp_socket_t *socket = amqp_tcp_socket_new(conn);
+    amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+    amqp_login(conn, "/", 0, AMQP_DEFAULT_FRAME_SIZE, 0, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+    const amqp_channel_t KChannel = 1;
+    amqp_channel_open(conn, KChannel);
+
+    amqp_bytes_t queueName(amqp_cstring_bytes("hello"));
+    amqp_queue_declare(conn, KChannel, queueName, false, false, false, false, amqp_empty_table);
+
+    amqp_confirm_select(conn, KChannel);
+    amqp_basic_publish(conn, KChannel, amqp_empty_bytes, /* routing key*/ queueName, false, false, nullptr, amqp_cstring_bytes("Hello World!"));
+    amqp_basic_publish(conn, KChannel, amqp_empty_bytes, /* routing key*/ queueName, false, false, nullptr, amqp_cstring_bytes("Hello World!"));
+
+    amqp_frame_t frame;
+    amqp_simple_wait_frame(conn, &frame);
+    if (frame.channel == KChannel)
+    {
+        if (frame.payload.method.id == AMQP_BASIC_ACK_METHOD)
+        {
+            amqp_basic_ack_t *ack = (amqp_basic_ack_t *)frame.payload.method.decoded;
+            if (ack->multiple)
+                std::cout << "Sucessfully sent messages up to delivery tag: " << ack->delivery_tag << std::endl;
+            else
+                std::cout << "Sucessfully sent message with delivery tag: " << ack->delivery_tag << std::endl;
+        }
+        else if (frame.payload.method.id == AMQP_BASIC_RETURN_METHOD)
+        {
+            // message wasn't routed to a queue, but returned
+            amqp_message_t returned_message;
+            amqp_read_message(conn, 1, &returned_message, 0);
+            amqp_destroy_message(&returned_message);
+
+            amqp_simple_wait_frame(conn, &frame);
+            if (frame.payload.method.id == AMQP_BASIC_ACK_METHOD)
+                std::cout << "Message returned" << std::endl;
+        }
+    }
+
+    amqp_channel_close(conn, KChannel, AMQP_REPLY_SUCCESS);
+    amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
+    amqp_destroy_connection(conn);
+    return 0;
+}

--- a/cpp/receive.cpp
+++ b/cpp/receive.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <string.h>
+
+#include <amqp.h>
+#include <amqp_tcp_socket.h>
+
+
+int main(int argc, char const *const *argv)
+{
+
+  amqp_connection_state_t conn = amqp_new_connection();
+
+  amqp_socket_t *socket = amqp_tcp_socket_new(conn);
+
+  amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+
+  amqp_login(conn, "/", 0, AMQP_DEFAULT_FRAME_SIZE, 0, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+  const amqp_channel_t KChannel = 1;
+  amqp_channel_open(conn, KChannel);
+
+  amqp_bytes_t queueName(amqp_cstring_bytes("hello"));
+  amqp_queue_declare(conn, KChannel, queueName, false, false, false, false, amqp_empty_table);
+
+  amqp_basic_consume(conn, KChannel, queueName, amqp_empty_bytes, false, /* auto ack*/true, false, amqp_empty_table);
+
+  for (;;)
+  {
+    amqp_maybe_release_buffers(conn);
+    amqp_envelope_t envelope;
+    amqp_consume_message(conn, &envelope, nullptr, 0);
+
+    std::cout << " [x] Received " << std::string((char *)envelope.message.body.bytes,(int)envelope.message.body.len) << std::endl;
+    amqp_destroy_envelope(&envelope);
+  }
+
+  amqp_channel_close(conn, KChannel, AMQP_REPLY_SUCCESS);
+  amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
+  amqp_destroy_connection(conn);
+
+  return 0;
+}

--- a/cpp/receive_logs.cpp
+++ b/cpp/receive_logs.cpp
@@ -1,0 +1,52 @@
+  #include <iostream>
+#include <string.h>
+#include <algorithm>
+#include <thread>
+#include <chrono>
+
+#include <amqp.h>
+#include <amqp_tcp_socket.h>
+
+
+int main(int argc, char const *const *argv)
+{
+
+  amqp_connection_state_t conn = amqp_new_connection();
+  amqp_socket_t *socket = amqp_tcp_socket_new(conn);
+  amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+
+  amqp_login(conn, "/", 0, AMQP_DEFAULT_FRAME_SIZE, 0, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+  const amqp_channel_t KChannel = 1;
+  amqp_channel_open(conn, KChannel);
+
+  amqp_bytes_t exchangeName(amqp_cstring_bytes("logs"));
+  amqp_exchange_declare(conn, KChannel, exchangeName, amqp_cstring_bytes("fanout"), 
+                        false, false, false, false, amqp_empty_table);
+
+  amqp_queue_declare_ok_t *r = amqp_queue_declare(conn, KChannel, amqp_empty_bytes, false, false, true, false, amqp_empty_table);
+  amqp_bytes_t queueName = amqp_bytes_malloc_dup(r->queue);
+
+  amqp_queue_bind(conn, KChannel, queueName, exchangeName, amqp_empty_bytes, amqp_empty_table);
+
+  std::cout << "[*] Waiting for logs. To exit press CTRL+C'" << std::endl;
+  amqp_basic_consume(conn, KChannel, queueName, amqp_empty_bytes, false, /* auto ack*/true, false, amqp_empty_table);
+
+  for (;;)
+  {
+    amqp_maybe_release_buffers(conn);
+    amqp_envelope_t envelope;
+    amqp_consume_message(conn, &envelope, nullptr, 0);
+
+    std::string message((char *)envelope.message.body.bytes,(int)envelope.message.body.len);
+    std::cout << " [x] Received " <<  message << std::endl;
+
+    amqp_destroy_envelope(&envelope);
+  }
+
+  amqp_bytes_free(queueName);
+  amqp_channel_close(conn, KChannel, AMQP_REPLY_SUCCESS);
+  amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
+  amqp_destroy_connection(conn);
+
+  return 0;
+}

--- a/cpp/receive_logs_direct.cpp
+++ b/cpp/receive_logs_direct.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <string.h>
+#include <algorithm>
+#include <thread>
+#include <chrono>
+
+#include <amqp.h>
+#include <amqp_tcp_socket.h>
+
+int main(int argc, char const *const *argv)
+{
+
+  amqp_connection_state_t conn = amqp_new_connection();
+  amqp_socket_t *socket = amqp_tcp_socket_new(conn);
+  amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+
+  amqp_login(conn, "/", 0, AMQP_DEFAULT_FRAME_SIZE, 0, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+  const amqp_channel_t KChannel = 1;
+  amqp_channel_open(conn, KChannel);
+
+  amqp_bytes_t exchangeName(amqp_cstring_bytes("direct_logs"));
+  amqp_exchange_declare(conn, KChannel, exchangeName, amqp_cstring_bytes("direct"),
+                        false, false, false, false, amqp_empty_table);
+
+  amqp_queue_declare_ok_t *r = amqp_queue_declare(conn, KChannel, amqp_empty_bytes, false, false, /*exclusive*/ true, false, amqp_empty_table);
+  amqp_bytes_t queueName = amqp_bytes_malloc_dup(r->queue);
+
+  if (argc > 1)
+  {
+    for (int i = 1; i < argc; ++i)
+      amqp_queue_bind(conn, KChannel, queueName, exchangeName, amqp_cstring_bytes(argv[i]), amqp_empty_table);
+  }
+  else
+  {
+    std::cout << "Usage: " << argv[0] << " [info] [warning] [error]" << std::endl;
+    return 1;
+  }
+
+  std::cout << "[*] Waiting for logs. To exit press CTRL+C'" << std::endl;
+  amqp_basic_consume(conn, KChannel, queueName, amqp_empty_bytes, false, /* auto ack*/ true, false, amqp_empty_table);
+
+  for (;;)
+  {
+    amqp_maybe_release_buffers(conn);
+    amqp_envelope_t envelope;
+    amqp_consume_message(conn, &envelope, nullptr, 0);
+
+    std::string message((char *)envelope.message.body.bytes, (int)envelope.message.body.len);
+    std::cout << " [x] Received " << std::string((char*)envelope.routing_key.bytes, (int)envelope.routing_key.len) << ":" << message << std::endl;
+
+    amqp_destroy_envelope(&envelope);
+  }
+
+  amqp_bytes_free(queueName);
+  amqp_channel_close(conn, KChannel, AMQP_REPLY_SUCCESS);
+  amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
+  amqp_destroy_connection(conn);
+
+  return 0;
+}

--- a/cpp/receive_logs_topic.cpp
+++ b/cpp/receive_logs_topic.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <string.h>
+#include <algorithm>
+#include <thread>
+#include <chrono>
+
+#include <amqp.h>
+#include <amqp_tcp_socket.h>
+
+int main(int argc, char const *const *argv)
+{
+
+  amqp_connection_state_t conn = amqp_new_connection();
+  amqp_socket_t *socket = amqp_tcp_socket_new(conn);
+  amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+
+  amqp_login(conn, "/", 0, AMQP_DEFAULT_FRAME_SIZE, 0, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+  const amqp_channel_t KChannel = 1;
+  amqp_channel_open(conn, KChannel);
+
+  amqp_bytes_t exchangeName(amqp_cstring_bytes("topic_logs"));
+  amqp_exchange_declare(conn, KChannel, exchangeName, amqp_cstring_bytes("topic"),
+                        false, false, false, false, amqp_empty_table);
+
+  amqp_queue_declare_ok_t *r = amqp_queue_declare(conn, KChannel, amqp_empty_bytes, false, false, /*exclusive*/ true, false, amqp_empty_table);
+  amqp_bytes_t queueName = amqp_bytes_malloc_dup(r->queue);
+
+  if (argc > 1)
+  {
+    for (int i = 1; i < argc; ++i)
+      amqp_queue_bind(conn, KChannel, queueName, exchangeName, amqp_cstring_bytes(argv[i]), amqp_empty_table);
+  }
+  else
+  {
+    std::cout << "Usage: " << argv[0] << " [binding_key] ..." << std::endl;
+    return 1;
+  }
+
+  std::cout << "[*] Waiting for logs. To exit press CTRL+C'" << std::endl;
+  amqp_basic_consume(conn, KChannel, queueName, amqp_empty_bytes, false, /* auto ack*/ true, false, amqp_empty_table);
+
+  for (;;)
+  {
+    amqp_maybe_release_buffers(conn);
+    amqp_envelope_t envelope;
+    amqp_consume_message(conn, &envelope, nullptr, 0);
+
+    std::string message((char *)envelope.message.body.bytes, (int)envelope.message.body.len);
+    std::cout << " [x] Received " << std::string((char*)envelope.routing_key.bytes, (int)envelope.routing_key.len) << ":" << message << std::endl;
+
+    amqp_destroy_envelope(&envelope);
+  }
+
+  amqp_bytes_free(queueName);
+  amqp_channel_close(conn, KChannel, AMQP_REPLY_SUCCESS);
+  amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
+  amqp_destroy_connection(conn);
+
+  return 0;
+}

--- a/cpp/rpc_client.cpp
+++ b/cpp/rpc_client.cpp
@@ -1,0 +1,89 @@
+#include <string.h>
+#include <iostream>
+
+#include <amqp.h>
+#include <amqp_tcp_socket.h>
+
+class FibonacciRpcClient
+{
+public:
+  FibonacciRpcClient()
+  {
+    m_conn = amqp_new_connection();
+    amqp_socket_t *socket = amqp_tcp_socket_new(m_conn);
+    amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+    amqp_login(m_conn, "/", 0, AMQP_DEFAULT_FRAME_SIZE, 0, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+
+    amqp_channel_open(m_conn, KChannel);
+
+    amqp_queue_declare_ok_t *r = amqp_queue_declare(m_conn, KChannel, amqp_empty_bytes, false, false, false, /*auto delete*/true, amqp_empty_table);
+    m_callbackQueue = amqp_bytes_malloc_dup(r->queue);
+  }
+
+  int call(int n)
+  {
+    m_corr_id = std::to_string(++m_requestCount);
+
+    amqp_basic_properties_t props;
+    props._flags = AMQP_BASIC_CORRELATION_ID_FLAG | AMQP_BASIC_REPLY_TO_FLAG;
+    props.correlation_id = amqp_cstring_bytes(m_corr_id.c_str());
+    props.reply_to = m_callbackQueue;
+
+    amqp_bytes_t n_;
+    n_.bytes = &n;
+    n_.len = sizeof(n);
+    amqp_basic_publish(m_conn, KChannel, amqp_empty_bytes, /* routing key*/ amqp_cstring_bytes("rpc_queue"), false, false, &props, n_);
+
+    amqp_basic_consume(m_conn, KChannel, m_callbackQueue, amqp_empty_bytes, false, /* auto ack*/ true, false, amqp_empty_table);
+
+    int response = 0;
+    bool keepProcessing = true;
+    while (keepProcessing)
+    {
+      amqp_maybe_release_buffers(m_conn);
+      amqp_envelope_t envelope;
+      amqp_consume_message(m_conn, &envelope, nullptr, 0);
+
+      std::string correlation_id((char *)envelope.message.properties.correlation_id.bytes, (int)envelope.message.properties.correlation_id.len);
+      if (correlation_id == m_corr_id)
+      {
+        response = *(int *)envelope.message.body.bytes;
+        keepProcessing = false;
+      }
+
+      amqp_destroy_envelope(&envelope);
+    }
+
+    return response;
+  }
+
+  ~FibonacciRpcClient()
+  {
+    amqp_bytes_free(m_callbackQueue);
+    amqp_channel_close(m_conn, KChannel, AMQP_REPLY_SUCCESS);
+    amqp_connection_close(m_conn, AMQP_REPLY_SUCCESS);
+    amqp_destroy_connection(m_conn);
+  }
+
+private:
+  amqp_connection_state_t m_conn;
+  const amqp_channel_t KChannel = 1;
+  amqp_bytes_t m_callbackQueue;
+  std::string m_corr_id;
+  int m_requestCount = 0;
+};
+
+int main(int argc, char const *const *argv)
+{
+  int n = 30;
+  if (argc > 1)
+  {
+    n = std::stoi(argv[1]);
+  }
+
+  FibonacciRpcClient fibonacciRpcClient;
+  std::cout << " [x] Requesting fib(" << n << ")" << std::endl;
+  int response = fibonacciRpcClient.call(n);
+  std::cout << " [.] Got " << response << std::endl;
+  return 0;
+}

--- a/cpp/rpc_server.cpp
+++ b/cpp/rpc_server.cpp
@@ -1,0 +1,62 @@
+#include <string.h>
+#include <iostream>
+
+#include <amqp.h>
+#include <amqp_tcp_socket.h>
+
+int fib(int n)
+{
+  if (n == 0)
+    return 0;
+  else if (n == 1)
+    return 1;
+  else
+    return fib(n-1) + fib(n-2);
+}
+
+int main(int argc, char const *const *argv)
+{
+  amqp_connection_state_t conn = amqp_new_connection();
+  amqp_socket_t *socket = amqp_tcp_socket_new(conn);
+  amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+  amqp_login(conn, "/", 0, AMQP_DEFAULT_FRAME_SIZE, 0, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+  const amqp_channel_t KChannel = 1;
+  amqp_channel_open(conn, KChannel);
+
+  amqp_bytes_t queueName(amqp_cstring_bytes("rpc_queue"));
+  amqp_queue_declare(conn, KChannel, queueName, false, false, false, false, amqp_empty_table);
+
+  amqp_basic_qos(conn, KChannel, 0, /*prefetch_count*/1, 0);
+  amqp_basic_consume(conn, KChannel, queueName, amqp_empty_bytes, false, /* auto ack*/false, false, amqp_empty_table);
+  std::cout << " [x] Awaiting RPC requests" << std::endl;
+
+  for (;;)
+  {
+    amqp_maybe_release_buffers(conn);
+    amqp_envelope_t envelope;
+    amqp_rpc_reply_t res = amqp_consume_message(conn, &envelope, nullptr, 0);
+
+    int n = *(int *)envelope.message.body.bytes;
+    std::cout << " [.] fib(" <<  n << ")" << std::endl;
+    int response = fib(n);
+    amqp_bytes_t response_;
+    response_.bytes = &response;
+    response_.len = sizeof(response);
+
+    amqp_basic_properties_t props;
+    props._flags = AMQP_BASIC_CORRELATION_ID_FLAG;
+    props.correlation_id = envelope.message.properties.correlation_id;
+
+    amqp_channel_t replyChannel = envelope.channel;
+    amqp_basic_publish(conn, replyChannel, amqp_empty_bytes, /* routing key*/ envelope.message.properties.reply_to, false, false, &props, response_);
+    amqp_basic_ack(conn, replyChannel, envelope.delivery_tag, false);
+    
+    amqp_destroy_envelope(&envelope);
+  }
+
+  amqp_channel_close(conn, KChannel, AMQP_REPLY_SUCCESS);
+  amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
+  amqp_destroy_connection(conn);
+
+  return 0;
+}

--- a/cpp/send.cpp
+++ b/cpp/send.cpp
@@ -1,0 +1,26 @@
+#include <string.h>
+#include <iostream>
+
+#include <amqp.h>
+#include <amqp_tcp_socket.h>
+
+int main(int argc, char const *const *argv)
+{
+  amqp_connection_state_t conn = amqp_new_connection();
+  amqp_socket_t *socket = amqp_tcp_socket_new(conn);
+  amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+  amqp_login(conn, "/", 0, AMQP_DEFAULT_FRAME_SIZE, 0, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+  const amqp_channel_t KChannel = 1;
+  amqp_channel_open(conn, KChannel);
+
+  amqp_bytes_t queueName(amqp_cstring_bytes("hello"));
+  amqp_queue_declare(conn, KChannel, queueName, false, false, false, false, amqp_empty_table);
+
+  amqp_basic_publish(conn, KChannel, amqp_empty_bytes, /* routing key*/ queueName, false, false, nullptr, amqp_cstring_bytes("Hello World!"));
+  std::cout << " [x] Sent 'Hello World!'" << std::endl;
+
+  amqp_channel_close(conn, KChannel, AMQP_REPLY_SUCCESS);
+  amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
+  amqp_destroy_connection(conn);
+  return 0;
+}

--- a/cpp/worker.cpp
+++ b/cpp/worker.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <string.h>
+#include <algorithm>
+#include <thread>
+#include <chrono>
+
+#include <amqp.h>
+#include <amqp_tcp_socket.h>
+
+
+int main(int argc, char const *const *argv)
+{
+
+  amqp_connection_state_t conn = amqp_new_connection();
+  amqp_socket_t *socket = amqp_tcp_socket_new(conn);
+  amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+
+  amqp_login(conn, "/", 0, AMQP_DEFAULT_FRAME_SIZE, 0, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+  const amqp_channel_t KChannel = 1;
+  amqp_channel_open(conn, KChannel);
+
+  amqp_bytes_t queueName(amqp_cstring_bytes("task_queue"));
+  amqp_queue_declare(conn, KChannel, queueName, false, /*durable*/ true, false, true, amqp_empty_table);
+
+  amqp_basic_qos(conn, KChannel, 0, /*prefetch_count*/1, 0);
+  amqp_basic_consume(conn, KChannel, queueName, amqp_empty_bytes, false, /* auto ack*/false, false, amqp_empty_table);
+
+  for (;;)
+  {
+    amqp_maybe_release_buffers(conn);
+    amqp_envelope_t envelope;
+    amqp_consume_message(conn, &envelope, nullptr, 0);
+
+    std::string message((char *)envelope.message.body.bytes,(int)envelope.message.body.len);
+    std::cout << " [x] Received " <<  message << std::endl;
+    const int seconds = std::count(std::begin(message), std::end(message), '.');
+    std::this_thread::sleep_for(std::chrono::seconds(seconds));
+    std::cout << " [x] Done" << std::endl;
+
+    amqp_basic_ack(conn, KChannel, envelope.delivery_tag, false);
+    amqp_destroy_envelope(&envelope);
+  }
+
+  amqp_channel_close(conn, KChannel, AMQP_REPLY_SUCCESS);
+  amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
+  amqp_destroy_connection(conn);
+
+  return 0;
+}


### PR DESCRIPTION
I started getting to know rabbitmq recently and noticed there are no C++ code examples in rabbitmq GetStarted tutorials.
That's why I ported the examples to C++ and made them work. I thought it could be useful for other people, since there is no much documentation on rabbitmq-c C library that I used in the examples.

Cheers, Aleksandar