### PR TITLE
Fix to prevent a problem when not closing channel.

### DIFF
--- a/dotnet/RPCClient/RPCClient.cs
+++ b/dotnet/RPCClient/RPCClient.cs
@@ -56,6 +56,7 @@ public class RpcClient : IDisposable
 
     public void Dispose()
     {
+        channel.Close();
         connection.Close();
     }
 }


### PR DESCRIPTION
- System hangs on "await InvokeAsync(n);" inside method Main
   * I don't know the detail, connection.Close should handle this close connection, but something since is using same main resources is causing a block on main thread when channel.Close is not called.