### PR TITLE
Refactor Golang tutorial one 

### DIFF
--- a/go/go.work
+++ b/go/go.work
@@ -1,0 +1,3 @@
+go 1.21.0
+
+use ./tutorial-1

--- a/go/tutorial-1/go.mod
+++ b/go/tutorial-1/go.mod
@@ -1,0 +1,5 @@
+module github.com/mateusmlo/rabbitmq-tutorials/go/tutorial-1
+
+go 1.21.0
+
+require github.com/rabbitmq/amqp091-go v1.8.1 // indirect

--- a/go/tutorial-1/go.mod
+++ b/go/tutorial-1/go.mod
@@ -1,4 +1,4 @@
-module github.com/mateusmlo/rabbitmq-tutorials/go/tutorial-1
+module github.com/rabbitmq/rabbitmq-tutorials/go/tutorial-1
 
 go 1.21.0
 

--- a/go/tutorial-1/go.sum
+++ b/go/tutorial-1/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rabbitmq/amqp091-go v1.8.1 h1:RejT1SBUim5doqcL6s7iN6SBmsQqyTgXb1xMlH0h1hA=
+github.com/rabbitmq/amqp091-go v1.8.1/go.mod h1:+jPrT9iY2eLjRaMSRHUhc3z14E/l85kv/f+6luSD3pc=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/tutorial-1/main.go
+++ b/go/tutorial-1/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os"
+
+	"github.com/mateusmlo/rabbitmq-tutorials/go/tutorial-1/receive"
+	"github.com/mateusmlo/rabbitmq-tutorials/go/tutorial-1/send"
+)
+
+func main() {
+	arg1 := os.Args[1]
+
+	if arg1 == "send" {
+		send.Send()
+	}
+
+	if arg1 == "receive" {
+		receive.Receive()
+	}
+}

--- a/go/tutorial-1/main.go
+++ b/go/tutorial-1/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"os"
 
-	"github.com/mateusmlo/rabbitmq-tutorials/go/tutorial-1/receive"
-	"github.com/mateusmlo/rabbitmq-tutorials/go/tutorial-1/send"
+	"github.com/rabbitmq/rabbitmq-tutorials/go/tutorial-1/receive"
+	"github.com/rabbitmq/rabbitmq-tutorials/go/tutorial-1/send"
 )
 
 func main() {

--- a/go/tutorial-1/receive/receive.go
+++ b/go/tutorial-1/receive/receive.go
@@ -1,0 +1,56 @@
+package receive
+
+import (
+	"log"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+func failOnError(err error, msg string) {
+	if err != nil {
+		log.Panicf("%s: %s", msg, err)
+	}
+}
+
+// Receive consumes messages from queue
+func Receive() {
+	conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
+	failOnError(err, "Failed to connect to RabbitMQ")
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	failOnError(err, "Failed to open a channel")
+	defer ch.Close()
+
+	q, err := ch.QueueDeclare(
+		"hello", // name
+		false,   // durable
+		false,   // delete when unused
+		false,   // exclusive
+		false,   // no-wait
+		nil,     // arguments
+	)
+	failOnError(err, "Failed to declare a queue")
+
+	msgs, err := ch.Consume(
+		q.Name, // queue
+		"",     // consumer
+		true,   // auto-ack
+		false,  // exclusive
+		false,  // no-local
+		false,  // no-wait
+		nil,    // args
+	)
+	failOnError(err, "Failed to register a consumer")
+
+	var forever chan struct{}
+
+	go func() {
+		for d := range msgs {
+			log.Printf("Received a message: %s", d.Body)
+		}
+	}()
+
+	log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
+	<-forever
+}

--- a/go/tutorial-1/send/send.go
+++ b/go/tutorial-1/send/send.go
@@ -1,0 +1,51 @@
+package send
+
+import (
+	"context"
+	"log"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+func failOnError(err error, msg string) {
+	if err != nil {
+		log.Panicf("%s: %s", msg, err)
+	}
+}
+
+// Send sends message to queue
+func Send() {
+	conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
+	failOnError(err, "Failed to connect to RabbitMQ")
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	failOnError(err, "Failed to open a channel")
+	defer ch.Close()
+
+	q, err := ch.QueueDeclare(
+		"hello", // name
+		false,   // durable
+		false,   // delete when unused
+		false,   // exclusive
+		false,   // no-wait
+		nil,     // arguments
+	)
+	failOnError(err, "Failed to declare a queue")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	body := "Hello World!"
+	err = ch.PublishWithContext(ctx,
+		"",     // exchange
+		q.Name, // routing key
+		false,  // mandatory
+		false,  // immediate
+		amqp.Publishing{
+			ContentType: "text/plain",
+			Body:        []byte(body),
+		})
+	failOnError(err, "Failed to publish a message")
+	log.Printf(" [x] Sent %s\n", body)
+}


### PR DESCRIPTION
Works on issue #364 
I've also made the necessary adjustments to the website tutorial in the following PR https://github.com/rabbitmq/rabbitmq-website/pull/1724.
The `go.work` file is there so the compiler won't complain about submodules, as the idea is each tutorial being a separate mini-project (just like the Objective-C ones), so in the future we may remove the root level `go.mod` and `go.sum`.