### PR TITLE
Fix: make python code fellow pep8

### DIFF
--- a/python/emit_log.py
+++ b/python/emit_log.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-import pika
 import sys
+
+import pika
 
 connection = pika.BlockingConnection(
     pika.ConnectionParameters(host='localhost'))

--- a/python/emit_log_direct.py
+++ b/python/emit_log_direct.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-import pika
 import sys
+
+import pika
 
 connection = pika.BlockingConnection(
     pika.ConnectionParameters(host='localhost'))

--- a/python/emit_log_topic.py
+++ b/python/emit_log_topic.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-import pika
 import sys
+
+import pika
 
 connection = pika.BlockingConnection(
     pika.ConnectionParameters(host='localhost'))

--- a/python/new_task.py
+++ b/python/new_task.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-import pika
 import sys
+
+import pika
 
 connection = pika.BlockingConnection(
     pika.ConnectionParameters(host='localhost'))

--- a/python/receive.py
+++ b/python/receive.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-import pika, sys, os
+import os
+import pika
+import sys
+
 
 def main():
     connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
@@ -14,6 +17,7 @@ def main():
 
     print(' [*] Waiting for messages. To exit press CTRL+C')
     channel.start_consuming()
+
 
 if __name__ == '__main__':
     try:

--- a/python/receive_logs.py
+++ b/python/receive_logs.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-import pika, sys, os
+import os
+import pika
+import sys
+
 
 def main():
     connection = pika.BlockingConnection(

--- a/python/receive_logs_direct.py
+++ b/python/receive_logs_direct.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
-import pika, sys, os
+import os
+import pika
+import sys
+
 
 def main():
     connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+        pika.ConnectionParameters(host='localhost'))
     channel = connection.channel()
 
     channel.exchange_declare(exchange='direct_logs', exchange_type='direct')
@@ -22,10 +25,8 @@ def main():
 
     print(' [*] Waiting for logs. To exit press CTRL+C')
 
-
     def callback(ch, method, properties, body):
         print(f" [x] {method.routing_key}:{body.decode()}")
-
 
     channel.basic_consume(
         queue=queue_name, on_message_callback=callback, auto_ack=True)

--- a/python/receive_logs_topic.py
+++ b/python/receive_logs_topic.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
-import pika, sys, os
+import os
+import pika
+import sys
+
 
 def main():
     connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+        pika.ConnectionParameters(host='localhost'))
     channel = connection.channel()
 
     channel.exchange_declare(exchange='topic_logs', exchange_type='topic')
@@ -22,10 +25,8 @@ def main():
 
     print(' [*] Waiting for logs. To exit press CTRL+C')
 
-
     def callback(ch, method, properties, body):
         print(f" [x] {method.routing_key}:{body.decode()}")
-
 
     channel.basic_consume(
         queue=queue_name, on_message_callback=callback, auto_ack=True)

--- a/python/rpc_client.py
+++ b/python/rpc_client.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-import pika
 import uuid
+
+import pika
 
 
 class FibonacciRpcClient(object):

--- a/python/rpc_server.py
+++ b/python/rpc_server.py
@@ -26,7 +26,7 @@ def on_request(ch, method, props, body):
 
     ch.basic_publish(exchange='',
                      routing_key=props.reply_to,
-                     properties=pika.BasicProperties(correlation_id = \
+                     properties=pika.BasicProperties(correlation_id= \
                                                          props.correlation_id),
                      body=str(response))
     ch.basic_ack(delivery_tag=method.delivery_tag)

--- a/python/worker.py
+++ b/python/worker.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-import pika
 import time
+
+import pika
 
 connection = pika.BlockingConnection(
     pika.ConnectionParameters(host='localhost'))


### PR DESCRIPTION
There are some trivial format errors which will cause many warnings in some IDEs and may misleading the users. Take `python/receive.py` for example, the [PEP8](https://peps.python.org/pep-0008/) errors are as fellows: 

- PEP 8: E401 multiple imports on one line
https://github.com/rabbitmq/rabbitmq-tutorials/blob/2773e7339d16987543e9454d773778a989ef02bb/python/receive.py#L2
- PEP 8: E302 expected 2 blank lines, found 1
https://github.com/rabbitmq/rabbitmq-tutorials/blob/2773e7339d16987543e9454d773778a989ef02bb/python/receive.py#L4
- PEP 8: E305 expected 2 blank lines after class or function definition, found 1
https://github.com/rabbitmq/rabbitmq-tutorials/blob/2773e7339d16987543e9454d773778a989ef02bb/python/receive.py#L18

The python code here will be showed in the tutorial documentation which will be seen by lots of users, so I think make the code fellow the PEP8 is a better choice.