### PR TITLE
fix: pika version 1.3.2

### DIFF
--- a/python/new_task.py
+++ b/python/new_task.py
@@ -15,7 +15,7 @@ channel.basic_publish(
     routing_key='task_queue',
     body=message,
     properties=pika.BasicProperties(
-        delivery_mode=pika.spec.PERSISTENT_DELIVERY_MODE,
+        delivery_mode=pika.DeliveryMode.Persistent,
     ))
 print(f" [x] Sent {message}")
 connection.close()


### PR DESCRIPTION
- When tested with most recent pika's version 1.3.2, spec didn't exists. Found pika.DeliveryMode.Persistent instead.