### PR TITLE
style: format python code

### DIFF
--- a/python/emit_log.py
+++ b/python/emit_log.py
@@ -4,12 +4,14 @@ import sys
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.exchange_declare(exchange='logs', exchange_type='fanout')
 
-message = ' '.join(sys.argv[1:]) or "info: Hello World!"
+message = ' '.join(sys.argv[1:]) or 'info: Hello World!'
 channel.basic_publish(exchange='logs', routing_key='', body=message)
-print(f" [x] Sent {message}")
+print(f' [x] Sent {message}')
+
 connection.close()

--- a/python/emit_log_direct.py
+++ b/python/emit_log_direct.py
@@ -4,7 +4,8 @@ import sys
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.exchange_declare(exchange='direct_logs', exchange_type='direct')
@@ -12,6 +13,10 @@ channel.exchange_declare(exchange='direct_logs', exchange_type='direct')
 severity = sys.argv[1] if len(sys.argv) > 2 else 'info'
 message = ' '.join(sys.argv[2:]) or 'Hello World!'
 channel.basic_publish(
-    exchange='direct_logs', routing_key=severity, body=message)
-print(f" [x] Sent {severity}:{message}")
+    exchange='direct_logs',
+    routing_key=severity,
+    body=message,
+)
+print(f' [x] Sent {severity}:{message}')
+
 connection.close()

--- a/python/emit_log_topic.py
+++ b/python/emit_log_topic.py
@@ -4,7 +4,8 @@ import sys
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.exchange_declare(exchange='topic_logs', exchange_type='topic')
@@ -12,6 +13,10 @@ channel.exchange_declare(exchange='topic_logs', exchange_type='topic')
 routing_key = sys.argv[1] if len(sys.argv) > 2 else 'anonymous.info'
 message = ' '.join(sys.argv[2:]) or 'Hello World!'
 channel.basic_publish(
-    exchange='topic_logs', routing_key=routing_key, body=message)
-print(f" [x] Sent {routing_key}:{message}")
+    exchange='topic_logs',
+    routing_key=routing_key,
+    body=message,
+)
+print(f' [x] Sent {routing_key}:{message}')
+
 connection.close()

--- a/python/new_task.py
+++ b/python/new_task.py
@@ -4,18 +4,21 @@ import sys
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.queue_declare(queue='task_queue', durable=True)
 
-message = ' '.join(sys.argv[1:]) or "Hello World!"
+message = ' '.join(sys.argv[1:]) or 'Hello World!'
 channel.basic_publish(
     exchange='',
     routing_key='task_queue',
     body=message,
     properties=pika.BasicProperties(
         delivery_mode=pika.DeliveryMode.Persistent,
-    ))
-print(f" [x] Sent {message}")
+    ),
+)
+print(f' [x] Sent {message}')
+
 connection.close()

--- a/python/receive.py
+++ b/python/receive.py
@@ -1,19 +1,26 @@
 #!/usr/bin/env python
 import os
-import pika
 import sys
+
+import pika
 
 
 def main():
-    connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+    connection = pika.BlockingConnection(
+        pika.ConnectionParameters(host='localhost'),
+    )
     channel = connection.channel()
 
     channel.queue_declare(queue='hello')
 
     def callback(ch, method, properties, body):
-        print(f" [x] Received {body.decode()}")
+        print(f' [x] Received {body.decode()}')
 
-    channel.basic_consume(queue='hello', on_message_callback=callback, auto_ack=True)
+    channel.basic_consume(
+        queue='hello',
+        on_message_callback=callback,
+        auto_ack=True,
+    )
 
     print(' [*] Waiting for messages. To exit press CTRL+C')
     channel.start_consuming()

--- a/python/receive_logs.py
+++ b/python/receive_logs.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 import os
-import pika
 import sys
+
+import pika
 
 
 def main():
     connection = pika.BlockingConnection(
-        pika.ConnectionParameters(host='localhost'))
+        pika.ConnectionParameters(host='localhost'),
+    )
     channel = connection.channel()
 
     channel.exchange_declare(exchange='logs', exchange_type='fanout')
@@ -17,11 +19,14 @@ def main():
     channel.queue_bind(exchange='logs', queue=queue_name)
 
     def callback(ch, method, properties, body):
-        print(f" [x] {body.decode()}")
+        print(f' [x] {body.decode()}')
 
     print(' [*] Waiting for logs. To exit press CTRL+C')
     channel.basic_consume(
-        queue=queue_name, on_message_callback=callback, auto_ack=True)
+        queue=queue_name,
+        on_message_callback=callback,
+        auto_ack=True,
+    )
 
     channel.start_consuming()
 

--- a/python/receive_logs_direct.py
+++ b/python/receive_logs_direct.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 import os
-import pika
 import sys
+
+import pika
 
 
 def main():
     connection = pika.BlockingConnection(
-        pika.ConnectionParameters(host='localhost'))
+        pika.ConnectionParameters(host='localhost'),
+    )
     channel = connection.channel()
 
     channel.exchange_declare(exchange='direct_logs', exchange_type='direct')
@@ -16,20 +18,26 @@ def main():
 
     severities = sys.argv[1:]
     if not severities:
-        sys.stderr.write("Usage: %s [info] [warning] [error]\n" % sys.argv[0])
+        sys.stderr.write('Usage: %s [info] [warning] [error]\n' % sys.argv[0])
         sys.exit(1)
 
     for severity in severities:
         channel.queue_bind(
-            exchange='direct_logs', queue=queue_name, routing_key=severity)
+            exchange='direct_logs',
+            queue=queue_name,
+            routing_key=severity,
+        )
 
     print(' [*] Waiting for logs. To exit press CTRL+C')
 
     def callback(ch, method, properties, body):
-        print(f" [x] {method.routing_key}:{body.decode()}")
+        print(f' [x] {method.routing_key}:{body.decode()}')
 
     channel.basic_consume(
-        queue=queue_name, on_message_callback=callback, auto_ack=True)
+        queue=queue_name,
+        on_message_callback=callback,
+        auto_ack=True,
+    )
 
     channel.start_consuming()
 

--- a/python/receive_logs_topic.py
+++ b/python/receive_logs_topic.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 import os
-import pika
 import sys
+
+import pika
 
 
 def main():
     connection = pika.BlockingConnection(
-        pika.ConnectionParameters(host='localhost'))
+        pika.ConnectionParameters(host='localhost'),
+    )
     channel = connection.channel()
 
     channel.exchange_declare(exchange='topic_logs', exchange_type='topic')
@@ -16,20 +18,26 @@ def main():
 
     binding_keys = sys.argv[1:]
     if not binding_keys:
-        sys.stderr.write("Usage: %s [binding_key]...\n" % sys.argv[0])
+        sys.stderr.write('Usage: %s [binding_key]...\n' % sys.argv[0])
         sys.exit(1)
 
     for binding_key in binding_keys:
         channel.queue_bind(
-            exchange='topic_logs', queue=queue_name, routing_key=binding_key)
+            exchange='topic_logs',
+            queue=queue_name,
+            routing_key=binding_key,
+        )
 
     print(' [*] Waiting for logs. To exit press CTRL+C')
 
     def callback(ch, method, properties, body):
-        print(f" [x] {method.routing_key}:{body.decode()}")
+        print(f' [x] {method.routing_key}:{body.decode()}')
 
     channel.basic_consume(
-        queue=queue_name, on_message_callback=callback, auto_ack=True)
+        queue=queue_name,
+        on_message_callback=callback,
+        auto_ack=True,
+    )
 
     channel.start_consuming()
 

--- a/python/rpc_client.py
+++ b/python/rpc_client.py
@@ -8,7 +8,8 @@ class FibonacciRpcClient(object):
 
     def __init__(self):
         self.connection = pika.BlockingConnection(
-            pika.ConnectionParameters(host='localhost'))
+            pika.ConnectionParameters(host='localhost'),
+        )
 
         self.channel = self.connection.channel()
 
@@ -18,7 +19,8 @@ class FibonacciRpcClient(object):
         self.channel.basic_consume(
             queue=self.callback_queue,
             on_message_callback=self.on_response,
-            auto_ack=True)
+            auto_ack=True,
+        )
 
         self.response = None
         self.corr_id = None
@@ -37,13 +39,14 @@ class FibonacciRpcClient(object):
                 reply_to=self.callback_queue,
                 correlation_id=self.corr_id,
             ),
-            body=str(n))
+            body=str(n),
+        )
         self.connection.process_data_events(time_limit=None)
         return int(self.response)
 
 
 fibonacci_rpc = FibonacciRpcClient()
 
-print(" [x] Requesting fib(30)")
+print(' [x] Requesting fib(30)')
 response = fibonacci_rpc.call(30)
-print(f" [.] Got {response}")
+print(f' [.] Got {response}')

--- a/python/rpc_server.py
+++ b/python/rpc_server.py
@@ -2,8 +2,8 @@
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
-
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.queue_declare(queue='rpc_queue')
@@ -21,19 +21,20 @@ def fib(n):
 def on_request(ch, method, props, body):
     n = int(body)
 
-    print(f" [.] fib({n})")
+    print(f' [.] fib({n})')
     response = fib(n)
 
-    ch.basic_publish(exchange='',
-                     routing_key=props.reply_to,
-                     properties=pika.BasicProperties(correlation_id= \
-                                                         props.correlation_id),
-                     body=str(response))
+    ch.basic_publish(
+        exchange='',
+        routing_key=props.reply_to,
+        properties=pika.BasicProperties(correlation_id=props.correlation_id),
+        body=str(response),
+    )
     ch.basic_ack(delivery_tag=method.delivery_tag)
 
 
 channel.basic_qos(prefetch_count=1)
 channel.basic_consume(queue='rpc_queue', on_message_callback=on_request)
 
-print(" [x] Awaiting RPC requests")
+print(' [x] Awaiting RPC requests')
 channel.start_consuming()

--- a/python/send.py
+++ b/python/send.py
@@ -2,11 +2,13 @@
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.queue_declare(queue='hello')
 
 channel.basic_publish(exchange='', routing_key='hello', body='Hello World!')
 print(" [x] Sent 'Hello World!'")
+
 connection.close()

--- a/python/worker.py
+++ b/python/worker.py
@@ -4,7 +4,8 @@ import time
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.queue_declare(queue='task_queue', durable=True)
@@ -12,9 +13,9 @@ print(' [*] Waiting for messages. To exit press CTRL+C')
 
 
 def callback(ch, method, properties, body):
-    print(f" [x] Received {body.decode()}")
+    print(f' [x] Received {body.decode()}')
     time.sleep(body.count(b'.'))
-    print(" [x] Done")
+    print(' [x] Done')
     ch.basic_ack(delivery_tag=method.delivery_tag)
 
 


### PR DESCRIPTION
1. Replace double quotes with single quotes (where possible) for consistency
2. Format parameters into separate lines for clarity
3. Sort imports by standard