### PR TITLE
Update Gradle Version to 8.5 and README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ more about various [installation options](https://www.rabbitmq.com/download.html
 The following ports are available:
 
  * [C#](./dotnet)
- * [C# (with Visual Studio)](./dotnet-visual-studio)
- * [C# (.NET 6.0)](./dotnet-6)
  * [Clojure](./clojure)
  * [Common Lisp](./common-lisp)
  * [Dart](./dart)

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -28,34 +28,95 @@ of the tutorial directory.
 
 #### [Tutorial one: "Hello World!"](https://www.rabbitmq.com/tutorials/tutorial-one-dotnet.html)
 
-    dotnet run --project Receive/Receive.csproj
-    dotnet run --project Send/Send.csproj
+```bash
+# terminal tab 1
+dotnet run --project Receive/Receive.csproj
+
+# terminal tab 2
+dotnet run --project Send/Send.csproj
+```
 
 #### [Tutorial two: Work Queues](https://www.rabbitmq.com/tutorials/tutorial-two-dotnet.html)
 
-    dotnet run --project Worker/Worker.csproj
-    dotnet run --project NewTask/NewTask.csproj
+```bash
+# terminal tab 1
+dotnet run --project Worker/Worker.csproj
+
+# terminal tab 2
+dotnet run --project Worker/Worker.csproj
+
+# terminal tab 3
+dotnet run --project NewTask/NewTask.csproj "First Message"
+dotnet run --project NewTask/NewTask.csproj "Second Message"
+dotnet run --project NewTask/NewTask.csproj "Third Message"
+dotnet run --project NewTask/NewTask.csproj "Fourth Message"
+dotnet run --project NewTask/NewTask.csproj "Fifth Message"
+```
 
 #### [Tutorial three: Publish/Subscribe](https://www.rabbitmq.com/tutorials/tutorial-three-dotnet.html)
 
-    dotnet run --project ReceiveLogs/ReceiveLogs.csproj
-    dotnet run --project EmitLog/EmitLog.csproj
+```bash
+# terminal tab 1
+dotnet run --project ReceiveLogs/ReceiveLogs.csproj
+
+# terminal tab 2
+dotnet run --project ReceiveLogs/ReceiveLogs.csproj
+
+# terminal tab 3
+dotnet run --project EmitLog/EmitLog.csproj
+```
 
 #### [Tutorial four: Routing](https://www.rabbitmq.com/tutorials/tutorial-four-dotnet.html)
 
-    dotnet run --project ReceiveLogsDirect/ReceiveLogsDirect.csproj info
-    dotnet run --project EmitLogDirect/EmitLogDirect.csproj
+```bash
+# terminal tab 1
+dotnet run --project ReceiveLogsDirect/ReceiveLogsDirect.csproj warning error
+
+# terminal tab 2
+dotnet run --project ReceiveLogsDirect/ReceiveLogsDirect.csproj info warning error
+
+# terminal tab 3
+dotnet run --project EmitLogDirect/EmitLogDirect.csproj info "Run. Run. Or it will explode."
+dotnet run --project EmitLogDirect/EmitLogDirect.csproj warning "Run. Run. Or it will explode."
+dotnet run --project EmitLogDirect/EmitLogDirect.csproj error "Run. Run. Or it will explode."
+```
 
 #### [Tutorial five: Topics](https://www.rabbitmq.com/tutorials/tutorial-five-dotnet.html)
 
-    dotnet run --project ReceiveLogsTopic/ReceiveLogsTopic.csproj anonymous.info
-    dotnet run --project EmitLogTopic/EmitLogTopic.csproj
+```bash
+# terminal tab 1
+# To receive all the logs:
+dotnet run --project ReceiveLogsTopic/ReceiveLogsTopic.csproj "#"
+
+# To receive all logs from the facility "kern":
+dotnet run --project ReceiveLogsTopic/ReceiveLogsTopic.csproj "kern.*"
+
+# Or if you want to hear only about "critical" logs:
+dotnet run --project ReceiveLogsTopic/ReceiveLogsTopic.csproj "*.critical"
+
+# You can create multiple bindings:
+dotnet run --project ReceiveLogsTopic/ReceiveLogsTopic.csproj "kern.*" "*.critical"
+
+# terminal tab 2
+# And to emit a log with a routing key "kern.critical" type:
+dotnet run --project EmitLogTopic/EmitLogTopic.csproj kern.critical "A critical kernel error"
+```
 
 #### [Tutorial six: RPC](https://www.rabbitmq.com/tutorials/tutorial-six-dotnet.html)
 
-    dotnet run --project RPCServer/RPCServer.csproj
-    dotnet run --project RPCClient/RPCClient.csproj
+```bash
+# terminal tab 1
+# Our RPC service is now ready. We can start the server:
+dotnet run --project RPCServer/RPCServer.csproj
+
+# terminal tab 2
+# To request a fibonacci number run the client:
+dotnet run --project RPCClient/RPCClient.csproj
+```
 
 #### [Tutorial seven: Publisher Confirms](https://www.rabbitmq.com/tutorials/tutorial-seven-dotnet.html)
 
-    dotnet run --project PublisherConfirms/PublisherConfirms.csproj
+```bash
+# terminal tab 1
+dotnet run --project PublisherConfirms/PublisherConfirms.csproj
+```

--- a/java-gradle/README.md
+++ b/java-gradle/README.md
@@ -16,7 +16,7 @@ To successfully use the examples you will need a RabbitMQ node running locally.
 - Run pull-source-files.bat to replace symbolic link to the actual source file.
 
 ```shell
-.\pull-source-files.bat
+./pull-source-files.bat
 ```
 
 ## Code
@@ -25,82 +25,91 @@ To successfully use the examples you will need a RabbitMQ node running locally.
 
 ```shell
 # terminal tab 1
-gradle -Pmain=Recv run
+./gradlew -Pmain=Recv run
 
 # terminal tab 2
-gradle -Pmain=Send run
+./gradlew -Pmain=Send run
 ```
 
 #### [Tutorial two: Work Queues](https://www.rabbitmq.com/tutorials/tutorial-two-java.html):
 
 ```shell
 # terminal tab 1
-gradle -Pmain=Worker run
-gradle -Pmain=Worker run
+./gradlew -Pmain=Worker run
+./gradlew -Pmain=Worker run
 
 # terminal tab 2
-gradle -Pmain=NewTask run --args "First Message"
-gradle -Pmain=NewTask run --args "Second Message"
-gradle -Pmain=NewTask run --args "Third Message"
-gradle -Pmain=NewTask run --args "Fourth Message"
-gradle -Pmain=NewTask run --args "Fifth Message"
+./gradlew -Pmain=NewTask run --args "First Message"
+./gradlew -Pmain=NewTask run --args "Second Message"
+./gradlew -Pmain=NewTask run --args "Third Message"
+./gradlew -Pmain=NewTask run --args "Fourth Message"
+./gradlew -Pmain=NewTask run --args "Fifth Message"
 ```
 
 #### [Tutorial three: Publish/Subscribe](https://www.rabbitmq.com/tutorials/tutorial-three-java.html)
 
 ```shell
 # terminal tab 1
-gradle -Pmain=ReceiveLogs run
+./gradlew -Pmain=ReceiveLogs run
 
 # terminal tab 2
-gradle -Pmain=EmitLog run
+./gradlew -Pmain=ReceiveLogs run
+
+# terminal tab 3
+./gradlew -Pmain=EmitLog run
 ```
 
 #### [Tutorial four: Routing](https://www.rabbitmq.com/tutorials/tutorial-four-java.html)
 
 ```shell
 # terminal tab 1
-gradle -Pmain=ReceiveLogsDirect run --args "warning error"
+./gradlew -Pmain=ReceiveLogsDirect run --args "warning error"
 
 # terminal tab 2
-gradle -Pmain=ReceiveLogsDirect run --args "info warning error"
+./gradlew -Pmain=ReceiveLogsDirect run --args "info warning error"
 
 # terminal tab 3
-gradle -Pmain=EmitLogDirect run --args "error Run. Run. Or it will explode"
+./gradlew -Pmain=EmitLogDirect run --args 'info "Run. Run. Or it will explode"'
+./gradlew -Pmain=EmitLogDirect run --args 'warning "Run. Run. Or it will explode"'
+./gradlew -Pmain=EmitLogDirect run --args 'error "Run. Run. Or it will explode"'
 ```
 
 #### [Tutorial five: Topics](https://www.rabbitmq.com/tutorials/tutorial-five-java.html)
 
 ```shell
+# terminal tab 1
 # To receive all the logs:
-gradle -Pmain=ReceiveLogsTopic run --args "#"
+./gradlew -Pmain=ReceiveLogsTopic run --args "#"
 
 # To receive all logs from the facility "kern":
-gradle -Pmain=ReceiveLogsTopic run --args "kern.*"
+./gradlew -Pmain=ReceiveLogsTopic run --args "kern.*"
 
 # Or if you want to hear only about "critical" logs:
-gradle -Pmain=ReceiveLogsTopic run --args "*.critical"
+./gradlew -Pmain=ReceiveLogsTopic run --args "*.critical"
 
 # You can create multiple bindings:
-gradle -Pmain=ReceiveLogsTopic run --args "kern.* *.critical"
+./gradlew -Pmain=ReceiveLogsTopic run --args "kern.* *.critical"
 
+# terminal tab 2
 # And to emit a log with a routing key "kern.critical" type:
-gradle -Pmain=EmitLogTopic run --args "kern.critical A critical kernel error"
+./gradlew -Pmain=EmitLogTopic run --args "kern.critical A critical kernel error"
 ```
 
 #### [Tutorial six: RPC](https://www.rabbitmq.com/tutorials/tutorial-six-java.html)
 
 ```shell
+# terminal tab 1
 # Our RPC service is now ready. We can start the server:
-gradle -Pmain=RPCServer run
+./gradlew -Pmain=RPCServer run
 
+# terminal tab 2
 # To request a fibonacci number run the client:
-gradle -Pmain=RPCClient run
+./gradlew -Pmain=RPCClient run
 ```
 
 #### [Tutorial seven: Publisher Confirms](https://www.rabbitmq.com/tutorials/tutorial-seven-java.html)
 
 ```shell
-#
-gradle -Pmain=PublisherConfirms run
+# terminal tab 1
+./gradlew -Pmain=PublisherConfirms run
 ```

--- a/java-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/java-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request includes updates to a Gradle wrapper properties file, and modifications to the README files to enhance clarity and ease of following the tutorials.

The changes are as follows:

## java-gradle
Gradle Version Update: The Gradle distribution URL has been updated from gradle-7.5.1-bin.zip to gradle-8.5-bin.zip.
You can find the Java-Gradle Compatibility Matrix from [here](https://docs.gradle.org/current/userguide/compatibility.html)

## Readme.md (dotnet, java-gradle)
The README files have been updated to provide clearer and more detailed instructions for following the RabbitMQ tutorials using .NET and Java with Gradle.

I intended to upgrade dotnet version to 8.0, but found that rabbitmq-dotnet-client does support up to 7.0.
Thus, I dropped related commits.