### PR TITLE
Erlang Tutorial: Replace jsx with thoas in escript

### DIFF
--- a/erlang/README.md
+++ b/erlang/README.md
@@ -4,18 +4,18 @@ Here you can find a Erlang code examples from [RabbitMQ
 tutorials](https://www.rabbitmq.com/getstarted.html).
 
 This code is using [RabbitMQ Erlang
-Client](https://hg.rabbitmq.com/rabbitmq-erlang-client/) ([User
+Client](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/amqp_client) ([User
 Guide](https://www.rabbitmq.com/erlang-client-user-guide.html)).
 
 ## Requirements
 
 To run this code you need at least [Erlang
-R13B03](https://www.erlang.org/download.html), on Ubuntu you can get it
+R13B03](https://www.erlang.org/downloads), on Ubuntu you can get it
 using apt:
 
     sudo apt-get install erlang
 
-You also need rebar3: https://rebar3.readme.io/docs/getting-started
+You also need rebar3: https://www.rebar3.org/docs/getting-started/
 
 You need Erlang Client binaries:
 

--- a/erlang/emit_log.erl
+++ b/erlang/emit_log.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/jsx/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin
+%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/thoas/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 

--- a/erlang/emit_log_direct.erl
+++ b/erlang/emit_log_direct.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/jsx/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin
+%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/thoas/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 

--- a/erlang/emit_log_topic.erl
+++ b/erlang/emit_log_topic.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/jsx/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin
+%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/thoas/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 

--- a/erlang/new_task.erl
+++ b/erlang/new_task.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/jsx/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin
+%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/thoas/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 

--- a/erlang/receive.erl
+++ b/erlang/receive.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/jsx/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin 
+%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/thoas/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin 
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 

--- a/erlang/receive_logs.erl
+++ b/erlang/receive_logs.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/jsx/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin 
+%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/thoas/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin 
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 

--- a/erlang/receive_logs_direct.erl
+++ b/erlang/receive_logs_direct.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/jsx/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin 
+%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/thoas/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin 
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 

--- a/erlang/receive_logs_topic.erl
+++ b/erlang/receive_logs_topic.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/jsx/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin 
+%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/thoas/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin 
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 

--- a/erlang/send.erl
+++ b/erlang/send.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/jsx/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin
+%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/thoas/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 

--- a/erlang/worker.erl
+++ b/erlang/worker.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/jsx/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin
+%%! -pz ./_build/default/lib/amqp_client/ebin ./_build/default/lib/credentials_obfuscation/ebin ./_build/default/lib/thoas/ebin ./_build/default/lib/rabbit_common/ebin ./_build/default/lib/recon/ebin
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 


### PR DESCRIPTION
This change aligns with the migration to `thoas`
starting from RabbitMQ 3.11.0, as announced in
https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.11.0

This is related to the issue I met when executing erlang tutorial.

```bash
./send.erl
```

The result:

```
=INFO REPORT==== 18-Jun-2024::23:23:39.633852 ===
application: tools
exited: stopped
type: temporary

=INFO REPORT==== 18-Jun-2024::23:23:39.636206 ===
application: ssl
exited: stopped
type: temporary

=INFO REPORT==== 18-Jun-2024::23:23:39.636429 ===
application: sasl
exited: stopped
type: temporary

=INFO REPORT==== 18-Jun-2024::23:23:39.636461 ===
application: public_key
exited: stopped
type: temporary

=INFO REPORT==== 18-Jun-2024::23:23:39.636480 ===
application: asn1
exited: stopped
type: temporary

=INFO REPORT==== 18-Jun-2024::23:23:39.636532 ===
application: crypto
exited: stopped
type: temporary

escript: exception throw: {error,{thoas,{"no such file or directory","thoas.app"}}}
in function amqp_connection
/1 (amqp_connection.erl, line 207)
in call from amqp_connection:'-ensure_started/0-lc$^0/1-0-'/1 (amqp_connection.erl, line 198)
in call from amqp_connection
/0 (amqp_connection.erl, line 198)
in call from amqp_connection
/2 (amqp_connection.erl, line 154)
```

After I apply this patch, all the erlang tutorials were executed successfully.