### PR TITLE
Fix Python Stream Tutorial

### DIFF
--- a/python-stream/receive.py
+++ b/python-stream/receive.py
@@ -23,14 +23,18 @@ async def receive():
             stream = message_context.consumer.get_stream(message_context.subscriber_name)
             print("Got message: {} from stream {}".format(msg, stream))
 
-        print("Press control +C to close")
+        print("Press control + C to close")
         await consumer.start()
         await consumer.subscribe(
             stream=STREAM_NAME,
             callback=on_message,
             offset_specification=ConsumerOffsetSpecification(OffsetType.FIRST, None),
         )
-        await consumer.run()
+        try:
+            await consumer.run()
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            print("Closing Consumer...")
+            return
 
 
 with asyncio.Runner() as runner:

--- a/python-stream/receive.py
+++ b/python-stream/receive.py
@@ -1,5 +1,4 @@
 import asyncio
-import signal
 
 from rstream import (
     AMQPMessage,
@@ -15,30 +14,27 @@ STREAM_RETENTION = 5000000000
 
 
 async def receive():
-    consumer = Consumer(host="localhost", username="guest", password="guest")
-    await consumer.create_stream(
-        STREAM_NAME, exists_ok=True, arguments={"MaxLengthBytes": STREAM_RETENTION}
-    )
+    async with Consumer(host="localhost", username="test", password="test") as consumer:
+        await consumer.create_stream(
+            STREAM_NAME, exists_ok=True, arguments={"max-length-bytes": STREAM_RETENTION}
+        )
 
-    loop = asyncio.get_event_loop()
-    loop.add_signal_handler(
-        signal.SIGINT, lambda: asyncio.create_task(consumer.close())
-    )
+        async def on_message(msg: AMQPMessage, message_context: MessageContext):
+            stream = message_context.consumer.get_stream(message_context.subscriber_name)
+            print("Got message: {} from stream {}".format(msg, stream))
+        try:
+            print("Press control +C to close")
+            await consumer.start()
+            await consumer.subscribe(
+                stream=STREAM_NAME,
+                callback=on_message,
+                offset_specification=ConsumerOffsetSpecification(OffsetType.FIRST, None),
+            )
+            await consumer.run()
+        except (KeyboardInterrupt, asyncio.exceptions.CancelledError):
+            print("Closing Consumer...")
+            await consumer.close()
+            raise
 
-    async def on_message(msg: AMQPMessage, message_context: MessageContext):
-        stream = message_context.consumer.get_stream(message_context.subscriber_name)
-        print("Got message: {} from stream {}".format(msg, stream))
-
-    print("Press control +C to close")
-    await consumer.start()
-    await consumer.subscribe(
-        stream=STREAM_NAME,
-        callback=on_message,
-        offset_specification=ConsumerOffsetSpecification(OffsetType.FIRST, None),
-    )
-    await consumer.run()
-    # give time to the consumer task to close the consumer
-    await asyncio.sleep(1)
-
-
-asyncio.run(receive())
+with asyncio.Runner() as runner:
+    runner.run(receive())

--- a/python-stream/receive.py
+++ b/python-stream/receive.py
@@ -14,7 +14,7 @@ STREAM_RETENTION = 5000000000
 
 
 async def receive():
-    async with Consumer(host="localhost", username="test", password="test") as consumer:
+    async with Consumer(host="localhost", username="guest", password="guest") as consumer:
         await consumer.create_stream(
             STREAM_NAME, exists_ok=True, arguments={"max-length-bytes": STREAM_RETENTION}
         )
@@ -22,19 +22,16 @@ async def receive():
         async def on_message(msg: AMQPMessage, message_context: MessageContext):
             stream = message_context.consumer.get_stream(message_context.subscriber_name)
             print("Got message: {} from stream {}".format(msg, stream))
-        try:
-            print("Press control +C to close")
-            await consumer.start()
-            await consumer.subscribe(
-                stream=STREAM_NAME,
-                callback=on_message,
-                offset_specification=ConsumerOffsetSpecification(OffsetType.FIRST, None),
-            )
-            await consumer.run()
-        except (KeyboardInterrupt, asyncio.exceptions.CancelledError):
-            print("Closing Consumer...")
-            await consumer.close()
-            raise
+
+        print("Press control +C to close")
+        await consumer.start()
+        await consumer.subscribe(
+            stream=STREAM_NAME,
+            callback=on_message,
+            offset_specification=ConsumerOffsetSpecification(OffsetType.FIRST, None),
+        )
+        await consumer.run()
+
 
 with asyncio.Runner() as runner:
     runner.run(receive())

--- a/python-stream/send.py
+++ b/python-stream/send.py
@@ -22,7 +22,6 @@ async def send():
         print(" [x] Hello, World! message sent")
 
         input(" [x] Press Enter to close the producer  ...")
-        await producer.close()
 
 with asyncio.Runner() as runner:
     runner.run(send())

--- a/python-stream/send.py
+++ b/python-stream/send.py
@@ -14,7 +14,7 @@ async def send():
         password="guest",
     ) as producer:
         await producer.create_stream(
-            STREAM_NAME, exists_ok=True, arguments={"MaxLengthBytes": STREAM_RETENTION}
+            STREAM_NAME, exists_ok=True, arguments={"max-length-bytes": STREAM_RETENTION}
         )
 
         await producer.send(stream=STREAM_NAME, message=b"Hello, World!")
@@ -22,6 +22,7 @@ async def send():
         print(" [x] Hello, World! message sent")
 
         input(" [x] Press Enter to close the producer  ...")
+        await producer.close()
 
-
-asyncio.run(send())
+with asyncio.Runner() as runner:
+    runner.run(send())


### PR DESCRIPTION
Hello!

As described [here](https://github.com/rabbitmq/rabbitmq-website/issues/1991),  I found a bug in the python tutorial where the arguments won't be parsed correctly. I have updated the tutorial code and am also working on an update to the rabbitmq-website docs to reflect these changes (if this PR goes through). 

I also changed the code to use asyncio.Runner() so that it will only require one Keyboard Interrupt to abort the [async code](https://docs.python.org/3/library/asyncio-runner.html#id3).

The final change I made was also to call producer.close() and consumer.close() when the programs are finished.

Thank you!