### PR TITLE
fixing website links to streaming tutorial_2 for python and rust

### DIFF
--- a/python-stream/README.md
+++ b/python-stream/README.md
@@ -21,7 +21,7 @@ Code examples are executed via `python3`:
     python3 send.py
     python3 receive.py
 
-[Tutorial two: "Offset tracking"]():
+[Tutorial two: "Offset tracking"](https://www.rabbitmq.com/tutorials/tutorial-two-python-stream):
 
     python3 offset_tracking_send.py
     python3 offset_tracking_receive.py

--- a/rust-stream/README.md
+++ b/rust-stream/README.md
@@ -21,7 +21,7 @@ Each cargo command should be launched in a separate shell.
     cargo run --bin receive
     cargo run --bin send
 
-#### [Tutorial one: "Offset tracking!"](https://www.rabbitmq.com/tutorials/tutorial-one-rust-stream.html)
+#### [Tutorial one: "Offset tracking!"](https://www.rabbitmq.com/tutorials/tutorial-two-rust-stream.html)
 
     cargo run --bin send_offset_tracking
     cargo run --bin receive_offset_tracking


### PR DESCRIPTION
Fix website link for python and rust tutorial two