### PR TITLE
fix: nodejs stream tutorial

### DIFF
--- a/javascript-nodejs-stream/offset_tracking_receive.js
+++ b/javascript-nodejs-stream/offset_tracking_receive.js
@@ -3,8 +3,6 @@ const rabbit = require("rabbitmq-stream-js-client");
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 async function main() {
-  const streamName = "stream-offset-tracking-javascript";
-
   console.log("Connecting...");
   const client = await rabbit.connect({
     hostname: "localhost",
@@ -13,6 +11,10 @@ async function main() {
     password: "guest",
     vhost: "/",
   });
+
+  console.log("Making sure the stream exists...");
+  const streamName = "stream-offset-tracking-javascript";
+  await client.createStream({ stream: streamName, arguments: {} });
 
   const consumerRef = "offset-tracking-tutorial";
   let firstOffset = undefined;
@@ -47,13 +49,10 @@ async function main() {
   console.log(`Start consuming...`);
   await sleep(2000);
   console.log(`Done consuming, first offset was ${firstOffset}, last offset was ${lastOffset}`);
-  process.exit(0);
 }
 
 main()
-  .then(async () => {
-    await new Promise(function () {});
-  })
+  .then(async () => process.exit(0))
   .catch((res) => {
     console.log("Error while receiving message!", res);
     process.exit(-1);

--- a/javascript-nodejs-stream/package-lock.json
+++ b/javascript-nodejs-stream/package-lock.json
@@ -8,7 +8,7 @@
       "name": "rabbitmq-stream-node-tutorial",
       "version": "1.0.0",
       "dependencies": {
-        "rabbitmq-stream-js-client": "^0.4.1"
+        "rabbitmq-stream-js-client": "^0.4.2"
       }
     },
     "node_modules/lru-cache": {
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/rabbitmq-stream-js-client": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/rabbitmq-stream-js-client/-/rabbitmq-stream-js-client-0.4.1.tgz",
-      "integrity": "sha512-Dny3vFup/TQMcWXIKQUl3hdQQC1/ixeUEf4uEgzvwaFK/dIaUhsBT4J7i0mD581TUbCNhXFw4uWEXle9bXdmtA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/rabbitmq-stream-js-client/-/rabbitmq-stream-js-client-0.4.2.tgz",
+      "integrity": "sha512-/hcTDZJ8oUnVZoWFwGbD278qZ7F2Yb4mSDmzUQ1kpZh+82C0xiCDa0+nYotGauwZXsXddjnyc5C6q6qaP2OU1A==",
       "dependencies": {
         "semver": "^7.5.4"
       }
@@ -60,9 +60,9 @@
       }
     },
     "rabbitmq-stream-js-client": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/rabbitmq-stream-js-client/-/rabbitmq-stream-js-client-0.4.1.tgz",
-      "integrity": "sha512-Dny3vFup/TQMcWXIKQUl3hdQQC1/ixeUEf4uEgzvwaFK/dIaUhsBT4J7i0mD581TUbCNhXFw4uWEXle9bXdmtA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/rabbitmq-stream-js-client/-/rabbitmq-stream-js-client-0.4.2.tgz",
+      "integrity": "sha512-/hcTDZJ8oUnVZoWFwGbD278qZ7F2Yb4mSDmzUQ1kpZh+82C0xiCDa0+nYotGauwZXsXddjnyc5C6q6qaP2OU1A==",
       "requires": {
         "semver": "^7.5.4"
       }

--- a/javascript-nodejs-stream/package.json
+++ b/javascript-nodejs-stream/package.json
@@ -9,6 +9,6 @@
     "receive": "node receive.js"
   },
   "dependencies": {
-    "rabbitmq-stream-js-client": "^0.4.1"
+    "rabbitmq-stream-js-client": "^0.4.2"
   }
 }


### PR DESCRIPTION
Updates the version of the rabbitmq-stream-js-client package, fixing the consumer beahviour on the offset-tracking example.
With reference to [this](https://github.com/rabbitmq/rabbitmq-tutorials/pull/445) pr.