### PR TITLE
javascript-nodejs: add optional Docker Compose setup for tutorials

### DIFF
--- a/javascript-nodejs/.dockerignore
+++ b/javascript-nodejs/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+README.md
+docker-compose.yml
+Dockerfile
+.dockerignore

--- a/javascript-nodejs/AGENTS.md
+++ b/javascript-nodejs/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent Notes: Node.js Tutorials
+
+## Broker connection
+
+`src/*.js` calls `amqp.connect(process.env.AMQP_URL || 'amqp://localhost')`.
+Keep that fallback when adding new tutorial files so both the standard
+`localhost` flow and the optional Docker Compose flow keep working.
+
+## Docker Compose
+
+`docker-compose.yml` is an optional convenience for running the tutorials in
+containers. Do not bind broker ports to `0.0.0.0`; keep them on `127.0.0.1`.
+The canonical path remains a RabbitMQ node on `localhost` with default
+settings, as required by the repo-wide `AGENTS.md`.

--- a/javascript-nodejs/Dockerfile
+++ b/javascript-nodejs/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY src ./src
+
+# Overridden per service in docker-compose.yml
+CMD ["node", "src/send.js"]

--- a/javascript-nodejs/README.md
+++ b/javascript-nodejs/README.md
@@ -65,3 +65,34 @@ node src/emit_log_topic.js red.rabbit Hello
 node src/rpc_server.js
 node src/rpc_client.js 30
 ```
+
+## Running with Docker Compose (optional)
+
+If you don't want to install RabbitMQ locally, you can alternatively run the
+tutorials inside containers using the included `docker-compose.yml`:
+
+``` shell
+docker compose up --build send receive
+```
+
+This starts a RabbitMQ broker (with the management UI on
+[http://localhost:15672](http://localhost:15672), default `guest`/`guest`
+credentials) and runs Tutorial 1 (`send` and `receive`).
+
+To run other tutorials with the same images, override the command on one of
+the existing services, for example:
+
+``` shell
+docker compose run --rm send node src/new_task.js "A very hard task..."
+docker compose run --rm receive node src/worker.js
+```
+
+The source files honor an optional `AMQP_URL` environment variable, falling
+back to `amqp://localhost`, so the same code runs unchanged against either a
+local broker or the broker started by Compose.
+
+To tear everything down, including the broker's volume:
+
+``` shell
+docker compose down -v
+```

--- a/javascript-nodejs/docker-compose.yml
+++ b/javascript-nodejs/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  rabbitmq:
+    image: rabbitmq:4-management-alpine
+    ports:
+      - "127.0.0.1:5672:5672"
+      - "127.0.0.1:15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  send:
+    build: .
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      AMQP_URL: amqp://rabbitmq
+    command: ["node", "src/send.js"]
+
+  receive:
+    build: .
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      AMQP_URL: amqp://rabbitmq
+    command: ["node", "src/receive.js"]

--- a/javascript-nodejs/src/emit_log.js
+++ b/javascript-nodejs/src/emit_log.js
@@ -3,7 +3,7 @@
 const amqp = require('amqplib');
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect(process.env.AMQP_URL || 'amqp://localhost');
     const channel = await connection.createChannel();
 
     const exchange = 'logs';

--- a/javascript-nodejs/src/emit_log_direct.js
+++ b/javascript-nodejs/src/emit_log_direct.js
@@ -3,7 +3,7 @@
 const amqp = require('amqplib');
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect(process.env.AMQP_URL || 'amqp://localhost');
     const channel = await connection.createChannel();
 
     const exchange = 'direct_logs';

--- a/javascript-nodejs/src/emit_log_topic.js
+++ b/javascript-nodejs/src/emit_log_topic.js
@@ -3,7 +3,7 @@
 const amqp = require('amqplib');
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect(process.env.AMQP_URL || 'amqp://localhost');
     const channel = await connection.createChannel();
 
     const exchange = 'topic_logs';

--- a/javascript-nodejs/src/new_task.js
+++ b/javascript-nodejs/src/new_task.js
@@ -3,7 +3,7 @@
 const amqp = require('amqplib');
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect(process.env.AMQP_URL || 'amqp://localhost');
     const channel = await connection.createChannel();
 
     const queue = 'task_queue';

--- a/javascript-nodejs/src/receive.js
+++ b/javascript-nodejs/src/receive.js
@@ -3,7 +3,7 @@
 const amqp = require('amqplib');
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect(process.env.AMQP_URL || 'amqp://localhost');
     const channel = await connection.createChannel();
 
     const queue = 'hello';

--- a/javascript-nodejs/src/receive_logs.js
+++ b/javascript-nodejs/src/receive_logs.js
@@ -3,7 +3,7 @@
 const amqp = require('amqplib');
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect(process.env.AMQP_URL || 'amqp://localhost');
     const channel = await connection.createChannel();
 
     const exchange = 'logs';

--- a/javascript-nodejs/src/receive_logs_direct.js
+++ b/javascript-nodejs/src/receive_logs_direct.js
@@ -10,7 +10,7 @@ if (args.length === 0) {
 }
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect(process.env.AMQP_URL || 'amqp://localhost');
     const channel = await connection.createChannel();
 
     const exchange = 'direct_logs';

--- a/javascript-nodejs/src/receive_logs_topic.js
+++ b/javascript-nodejs/src/receive_logs_topic.js
@@ -10,7 +10,7 @@ if (args.length === 0) {
 }
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect(process.env.AMQP_URL || 'amqp://localhost');
     const channel = await connection.createChannel();
 
     const exchange = 'topic_logs';

--- a/javascript-nodejs/src/rpc_client.js
+++ b/javascript-nodejs/src/rpc_client.js
@@ -10,7 +10,7 @@ if (args.length === 0) {
 }
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect(process.env.AMQP_URL || 'amqp://localhost');
     const channel = await connection.createChannel();
 
     const correlationId = generateUuid();

--- a/javascript-nodejs/src/rpc_server.js
+++ b/javascript-nodejs/src/rpc_server.js
@@ -3,7 +3,7 @@
 const amqp = require('amqplib');
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect(process.env.AMQP_URL || 'amqp://localhost');
     const channel = await connection.createChannel();
 
     const queue = 'rpc_queue';

--- a/javascript-nodejs/src/send.js
+++ b/javascript-nodejs/src/send.js
@@ -3,7 +3,7 @@
 const amqp = require('amqplib');
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect(process.env.AMQP_URL || 'amqp://localhost');
     const channel = await connection.createChannel();
 
     const queue = 'hello';

--- a/javascript-nodejs/src/worker.js
+++ b/javascript-nodejs/src/worker.js
@@ -3,7 +3,7 @@
 const amqp = require('amqplib');
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect(process.env.AMQP_URL || 'amqp://localhost');
     const channel = await connection.createChannel();
 
     const queue = 'task_queue';


### PR DESCRIPTION
## Summary

This PR adds an **optional Docker Compose setup** for the `javascript-nodejs/` tutorial examples, so they can be run without requiring a separately installed RabbitMQ broker.

The existing tutorial workflow remains unchanged.

## Motivation

The JavaScript tutorials currently assume a locally installed RabbitMQ instance:

```shell
node src/send.js
node src/receive.js
```

For newcomers, installing and configuring RabbitMQ can be friction before they can try the examples.

This PR provides an optional containerised workflow while preserving the existing localhost-based approach.

## Changes

Within `javascript-nodejs/` only:

* add `Dockerfile`
* add `.dockerignore`
* add `docker-compose.yml`
* update tutorial scripts to support configurable broker connection via `AMQP_URL`
* update `README.md` with optional Docker Compose usage instructions

The tutorial behaviour is unchanged when `AMQP_URL` is not set.

Current usage still works:

```javascript
const connection = await amqp.connect(process.env.AMQP_URL || 'amqp://localhost');
```

## Example usage

Run Tutorial 1:

```shell
cd javascript-nodejs
docker compose up --build send receive
```

Run other tutorials:

```shell
docker compose run --rm send node src/new_task.js "a hard task..."
docker compose run --rm receive node src/worker.js
```

## Scope

This PR intentionally:

* does not change tutorial semantics
* does not rename queues, exchanges, or files
* does not add new client dependencies
* does not change anything outside `javascript-nodejs/`

## Notes

Happy to adjust the implementation if maintainers prefer a different convention for:

* broker configuration
* environment variable naming
* README structure
* container layout
