### PR TITLE
Add a Node.js hybrid consumer-and-producer pipeline

### DIFF
--- a/javascript-nodejs-pipeline/.dockerignore
+++ b/javascript-nodejs-pipeline/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+README.md
+docker-compose.yml
+Dockerfile
+.dockerignore

--- a/javascript-nodejs-pipeline/.gitignore
+++ b/javascript-nodejs-pipeline/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/javascript-nodejs-pipeline/AGENTS.md
+++ b/javascript-nodejs-pipeline/AGENTS.md
@@ -1,0 +1,34 @@
+# Agent Notes: Node.js Pipeline Example
+
+This port is a Docker Compose-oriented Node.js pipeline example. Unlike the
+numbered `javascript-nodejs` tutorials, the scripts connect to
+`amqp://rabbitmq` because they are intended to run inside the Compose network.
+
+## Running the Example
+
+Use Docker Compose for end-to-end checks:
+
+```sh
+docker compose up --build consumer worker producer
+```
+
+The `producer` exits after sending its batch. The `worker` and `consumer` are
+long-running services.
+
+Manual `node` runs require the hostname `rabbitmq` to resolve to a running
+RabbitMQ broker.
+
+## Code Guidelines
+
+ * Keep the three scripts self-contained and close to the style of the numbered Node.js tutorials
+ * Keep `amqp://rabbitmq` unless the README and Compose setup are updated together
+ * Preserve the worker's publish-confirm-then-ack flow
+ * Use durable quorum queues for `pipeline.input` and `pipeline.output`
+ * Keep the transformation simple so the example stays focused on the pipeline pattern
+ * Avoid adding dependencies unless they are essential to the tutorial
+
+## Documentation
+
+ * Keep the README focused on runnable commands and the pipeline behavior
+ * Keep Docker Compose instructions first because they match the hard-coded broker hostname
+ * Do not add full stops to Markdown list items

--- a/javascript-nodejs-pipeline/AGENTS.md
+++ b/javascript-nodejs-pipeline/AGENTS.md
@@ -1,8 +1,15 @@
-# Agent Notes: Node.js Pipeline Example
+# Agent Notes: Node.js Pipeline Pattern
 
-This port is a Docker Compose-oriented Node.js pipeline example. Unlike the
-numbered `javascript-nodejs` tutorials, the scripts connect to
-`amqp://rabbitmq` because they are intended to run inside the Compose network.
+This port demonstrates a process that is both a RabbitMQ consumer and producer.
+Use it as the reference pattern when implementing a simple message pipeline:
+
+```text
+producer -> pipeline.input -> worker -> pipeline.output -> consumer
+```
+
+The worker consumes from `pipeline.input`, transforms each message, publishes
+the transformed message to `pipeline.output`, waits for broker confirmation,
+and only then acknowledges the original delivery.
 
 ## Running the Example
 
@@ -16,7 +23,25 @@ The `producer` exits after sending its batch. The `worker` and `consumer` are
 long-running services.
 
 Manual `node` runs require the hostname `rabbitmq` to resolve to a running
-RabbitMQ broker.
+RabbitMQ broker. The scripts intentionally use `amqp://rabbitmq` because the
+primary workflow is Docker Compose.
+
+## Implementing the Pattern
+
+ * Declare both input and output queues before consuming or publishing
+ * Use durable quorum queues for `pipeline.input` and `pipeline.output`
+ * Use manual acknowledgements on the input consumer
+ * Set `prefetch(1)` so each worker handles one unacknowledged delivery at a time
+ * Publish the transformed output message with `persistent: true`
+ * Use a confirm channel for publish-confirm-then-ack behavior
+ * Acknowledge the input delivery only after the output publish has been confirmed
+ * On publish failure, `nack` the input delivery with requeue enabled
+ * Keep the transformation small and visible in the worker
+
+This pattern preserves the original message until the broker has accepted the
+derived message. It can still produce duplicates if a worker crashes after the
+output publish is confirmed but before the input acknowledgement reaches the
+broker, so consumers should be prepared for duplicate messages in real systems.
 
 ## Code Guidelines
 

--- a/javascript-nodejs-pipeline/Dockerfile
+++ b/javascript-nodejs-pipeline/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY producer.js worker.js consumer.js ./
+
+# Overridden per service in docker-compose.yml
+CMD ["node", "worker.js"]

--- a/javascript-nodejs-pipeline/README.md
+++ b/javascript-nodejs-pipeline/README.md
@@ -3,8 +3,8 @@
 A self-contained Node.js example showing a process that is **both a consumer
 and a producer** on the same channel. The worker reads messages from one
 queue, transforms each one, republishes the result to a second queue, and
-only then acknowledges the input message — so a message is never dropped in
-transit and never silently re-delivered after a successful republish.
+acknowledges the input message after the broker confirms the republished
+message.
 
 This is a complementary example to the numbered RabbitMQ tutorials, focused
 on the hybrid-node pattern that sits at the heart of most real pipelines,
@@ -17,17 +17,15 @@ producer --> pipeline.input --> worker (consumer + producer) --> pipeline.output
 ```
 
  - `producer` publishes input messages into `pipeline.input`
- - `worker` consumes from `pipeline.input` and, for each delivery, publishes a transformed message to `pipeline.output` before acknowledging the input
+ - `worker` consumes from `pipeline.input`, publishes a transformed message to `pipeline.output`, and then acknowledges the input
  - `consumer` reads from `pipeline.output`
 
-`pipeline.input` and `pipeline.output` are both declared as durable quorum
-queues, so the worker can be restarted at any point without losing in-flight
-work.
+`pipeline.input` and `pipeline.output` are both durable quorum queues.
 
 ## How the worker behaves
 
- - `prefetch(1)` — one unacknowledged delivery at a time, so the worker never holds more than one message in memory and load is naturally spread across multiple worker replicas
- - **Publish-then-ack** — the input delivery is acknowledged *after* the transformed message has been handed to `sendToQueue`. If the worker crashes mid-transform, the original message is redelivered by the broker
+ - `prefetch(1)` — one unacknowledged delivery at a time, so the worker never holds more than one message in memory and load is spread across multiple worker replicas
+ - **Publish-confirm-then-ack** — the input delivery is acknowledged *after* the transformed message has been confirmed by the broker. If the worker crashes mid-transform or before the confirm arrives, the broker redelivers the original message
  - **Persistent output** — the republished message is marked persistent and lands in a quorum queue, so it survives broker restarts
 
 The transformation used here is intentionally trivial (uppercase the body)
@@ -41,27 +39,17 @@ so the focus stays on the topology and the acknowledgement flow.
 
 ## Requirements
 
-[Node.js](https://nodejs.org/en/download/) and the
-[`amqplib`](https://github.com/amqp-node/amqplib) client. The example
-connects to RabbitMQ at `amqp://localhost`, matching the style of the
-numbered Node.js tutorials in [`../javascript-nodejs`](../javascript-nodejs).
+### Docker Compose
 
-## Run against a local RabbitMQ
+To run the complete example, you need Docker with Docker Compose. The Compose
+file starts RabbitMQ and all three pipeline processes.
 
-Install dependencies once:
+### Manual Node.js run
 
-``` shell
-npm install
-```
-
-Then, in three terminals (start the consumer and the worker before the
-producer so the live output is easier to follow):
-
-``` shell
-node consumer.js
-node worker.js
-node producer.js
-```
+To run the scripts outside Docker, you need [Node.js](https://nodejs.org/en/download/)
+and the [`amqplib`](https://github.com/amqp-node/amqplib) client. The scripts
+connect to RabbitMQ at `amqp://rabbitmq`, so that host name must resolve to a
+running broker.
 
 ## Run under Docker Compose
 
@@ -75,8 +63,28 @@ To stand the whole pipeline up:
 docker compose up --build consumer worker producer
 ```
 
+The producer publishes its batch and exits. The worker and consumer keep
+running so you can inspect the queues or send another producer batch.
+
 To tear everything down, including the broker's volume:
 
 ``` shell
 docker compose down -v
+```
+
+## Run the Node.js scripts manually
+
+Install dependencies once:
+
+``` shell
+npm install
+```
+
+Then, in three terminals, start the consumer and the worker before the
+producer. This requires `rabbitmq` to resolve to the broker host:
+
+``` shell
+node consumer.js
+node worker.js
+node producer.js
 ```

--- a/javascript-nodejs-pipeline/README.md
+++ b/javascript-nodejs-pipeline/README.md
@@ -1,0 +1,82 @@
+# Hybrid Consumer-and-Producer pipeline (Node.js)
+
+A self-contained Node.js example showing a process that is **both a consumer
+and a producer** on the same channel. The worker reads messages from one
+queue, transforms each one, republishes the result to a second queue, and
+only then acknowledges the input message — so a message is never dropped in
+transit and never silently re-delivered after a successful republish.
+
+This is a complementary example to the numbered RabbitMQ tutorials, focused
+on the hybrid-node pattern that sits at the heart of most real pipelines,
+fan-out workers, and message routers.
+
+## The pattern
+
+```
+producer --> pipeline.input --> worker (consumer + producer) --> pipeline.output --> consumer
+```
+
+ - `producer` publishes input messages into `pipeline.input`
+ - `worker` consumes from `pipeline.input` and, for each delivery, publishes a transformed message to `pipeline.output` before acknowledging the input
+ - `consumer` reads from `pipeline.output`
+
+`pipeline.input` and `pipeline.output` are both declared as durable quorum
+queues, so the worker can be restarted at any point without losing in-flight
+work.
+
+## How the worker behaves
+
+ - `prefetch(1)` — one unacknowledged delivery at a time, so the worker never holds more than one message in memory and load is naturally spread across multiple worker replicas
+ - **Publish-then-ack** — the input delivery is acknowledged *after* the transformed message has been handed to `sendToQueue`. If the worker crashes mid-transform, the original message is redelivered by the broker
+ - **Persistent output** — the republished message is marked persistent and lands in a quorum queue, so it survives broker restarts
+
+The transformation used here is intentionally trivial (uppercase the body)
+so the focus stays on the topology and the acknowledgement flow.
+
+## Files
+
+ - `worker.js` — the hybrid consumer-and-producer
+ - `producer.js` — publishes a fixed batch of messages to `pipeline.input` and exits
+ - `consumer.js` — subscribes to `pipeline.output` and prints what arrives
+
+## Requirements
+
+[Node.js](https://nodejs.org/en/download/) and the
+[`amqplib`](https://github.com/amqp-node/amqplib) client. The example
+connects to RabbitMQ at `amqp://localhost`, matching the style of the
+numbered Node.js tutorials in [`../javascript-nodejs`](../javascript-nodejs).
+
+## Run against a local RabbitMQ
+
+Install dependencies once:
+
+``` shell
+npm install
+```
+
+Then, in three terminals (start the consumer and the worker before the
+producer so the live output is easier to follow):
+
+``` shell
+node consumer.js
+node worker.js
+node producer.js
+```
+
+## Run under Docker Compose
+
+The included `docker-compose.yml` defines a RabbitMQ broker (with the
+management UI on [http://localhost:15672](http://localhost:15672), default
+`guest`/`guest` credentials) and the three pipeline services.
+
+To stand the whole pipeline up:
+
+``` shell
+docker compose up --build consumer worker producer
+```
+
+To tear everything down, including the broker's volume:
+
+``` shell
+docker compose down -v
+```

--- a/javascript-nodejs-pipeline/consumer.js
+++ b/javascript-nodejs-pipeline/consumer.js
@@ -3,7 +3,7 @@
 const amqp = require('amqplib');
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect('amqp://rabbitmq');
     const channel = await connection.createChannel();
 
     const outputQueue = 'pipeline.output';

--- a/javascript-nodejs-pipeline/consumer.js
+++ b/javascript-nodejs-pipeline/consumer.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const amqp = require('amqplib');
+
+async function main() {
+    const connection = await amqp.connect('amqp://localhost');
+    const channel = await connection.createChannel();
+
+    const outputQueue = 'pipeline.output';
+
+    await channel.assertQueue(outputQueue, {
+        durable: true,
+        arguments: { 'x-queue-type': 'quorum' }
+    });
+
+    console.log(" [*] Waiting for messages in %s. To exit press CTRL+C", outputQueue);
+
+    channel.consume(outputQueue, function(msg) {
+        console.log(" [x] Received '%s'", msg.content.toString());
+    }, {
+        noAck: true
+    });
+}
+
+main();

--- a/javascript-nodejs-pipeline/docker-compose.yml
+++ b/javascript-nodejs-pipeline/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  rabbitmq:
+    image: rabbitmq:4-management-alpine
+    ports:
+      - "127.0.0.1:5672:5672"
+      - "127.0.0.1:15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  worker:
+    build: .
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    command: ["node", "worker.js"]
+
+  consumer:
+    build: .
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    command: ["node", "consumer.js"]
+
+  producer:
+    build: .
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    command: ["node", "producer.js"]

--- a/javascript-nodejs-pipeline/package-lock.json
+++ b/javascript-nodejs-pipeline/package-lock.json
@@ -1,0 +1,56 @@
+{
+  "name": "rabbitmq-node-pipeline-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rabbitmq-node-pipeline-example",
+      "version": "1.0.0",
+      "dependencies": {
+        "amqplib": "0.10.9"
+      }
+    },
+    "node_modules/amqplib": {
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.9.tgz",
+      "integrity": "sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-more-ints": "~1.0.0",
+        "url-parse": "~1.5.10"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
+      "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    }
+  }
+}

--- a/javascript-nodejs-pipeline/package.json
+++ b/javascript-nodejs-pipeline/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "rabbitmq-node-pipeline-example",
+  "version": "1.0.0",
+  "description": "Hybrid consumer-and-producer pipeline example for RabbitMQ in Node.js",
+  "scripts": {
+    "producer": "node producer.js",
+    "worker": "node worker.js",
+    "consumer": "node consumer.js"
+  },
+  "dependencies": {
+    "amqplib": "0.10.9"
+  }
+}

--- a/javascript-nodejs-pipeline/producer.js
+++ b/javascript-nodejs-pipeline/producer.js
@@ -3,7 +3,7 @@
 const amqp = require('amqplib');
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect('amqp://rabbitmq');
     const channel = await connection.createChannel();
 
     const inputQueue = 'pipeline.input';

--- a/javascript-nodejs-pipeline/producer.js
+++ b/javascript-nodejs-pipeline/producer.js
@@ -4,7 +4,7 @@ const amqp = require('amqplib');
 
 async function main() {
     const connection = await amqp.connect('amqp://rabbitmq');
-    const channel = await connection.createChannel();
+    const channel = await connection.createConfirmChannel();
 
     const inputQueue = 'pipeline.input';
 
@@ -19,6 +19,7 @@ async function main() {
         channel.sendToQueue(inputQueue, Buffer.from(msg), { persistent: true });
         console.log(" [x] Sent '%s' to %s", msg, inputQueue);
     }
+    await channel.waitForConfirms();
 
     setTimeout(function() {
         connection.close();

--- a/javascript-nodejs-pipeline/producer.js
+++ b/javascript-nodejs-pipeline/producer.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const amqp = require('amqplib');
+
+async function main() {
+    const connection = await amqp.connect('amqp://localhost');
+    const channel = await connection.createChannel();
+
+    const inputQueue = 'pipeline.input';
+
+    await channel.assertQueue(inputQueue, {
+        durable: true,
+        arguments: { 'x-queue-type': 'quorum' }
+    });
+
+    const total = 5;
+    for (let i = 1; i <= total; i++) {
+        const msg = `hello #${i}`;
+        channel.sendToQueue(inputQueue, Buffer.from(msg), { persistent: true });
+        console.log(" [x] Sent '%s' to %s", msg, inputQueue);
+    }
+
+    setTimeout(function() {
+        connection.close();
+        process.exit(0);
+    }, 500);
+}
+
+main();

--- a/javascript-nodejs-pipeline/worker.js
+++ b/javascript-nodejs-pipeline/worker.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+// A consumer-and-producer: reads from pipeline.input, transforms
+// each message, republishes it to pipeline.output, and only then
+// acknowledges the input message.
+
+const amqp = require('amqplib');
+
+async function main() {
+    const connection = await amqp.connect('amqp://localhost');
+    const channel = await connection.createChannel();
+
+    const inputQueue = 'pipeline.input';
+    const outputQueue = 'pipeline.output';
+
+    await channel.assertQueue(inputQueue, {
+        durable: true,
+        arguments: { 'x-queue-type': 'quorum' }
+    });
+    await channel.assertQueue(outputQueue, {
+        durable: true,
+        arguments: { 'x-queue-type': 'quorum' }
+    });
+
+    channel.prefetch(1);
+    console.log(" [*] Waiting for messages in %s. To exit press CTRL+C", inputQueue);
+
+    channel.consume(inputQueue, function(msg) {
+        const body = msg.content.toString();
+        const transformed = body.toUpperCase();
+
+        console.log(" [x] Received '%s', forwarding '%s' to %s", body, transformed, outputQueue);
+        channel.sendToQueue(outputQueue, Buffer.from(transformed), { persistent: true });
+        channel.ack(msg);
+    }, {
+        noAck: false
+    });
+}
+
+main();

--- a/javascript-nodejs-pipeline/worker.js
+++ b/javascript-nodejs-pipeline/worker.js
@@ -8,7 +8,7 @@ const amqp = require('amqplib');
 
 async function main() {
     const connection = await amqp.connect('amqp://rabbitmq');
-    const channel = await connection.createChannel();
+    const channel = await connection.createConfirmChannel();
 
     const inputQueue = 'pipeline.input';
     const outputQueue = 'pipeline.output';
@@ -25,13 +25,23 @@ async function main() {
     channel.prefetch(1);
     console.log(" [*] Waiting for messages in %s. To exit press CTRL+C", inputQueue);
 
-    channel.consume(inputQueue, function(msg) {
+    channel.consume(inputQueue, async function(msg) {
+        if (msg === null) {
+            return;
+        }
+
         const body = msg.content.toString();
         const transformed = body.toUpperCase();
 
         console.log(" [x] Received '%s', forwarding '%s' to %s", body, transformed, outputQueue);
-        channel.sendToQueue(outputQueue, Buffer.from(transformed), { persistent: true });
-        channel.ack(msg);
+        try {
+            channel.sendToQueue(outputQueue, Buffer.from(transformed), { persistent: true });
+            await channel.waitForConfirms();
+            channel.ack(msg);
+        } catch (err) {
+            console.error(" [!] Failed to forward '%s': %s", body, err.message);
+            channel.nack(msg, false, true);
+        }
     }, {
         noAck: false
     });

--- a/javascript-nodejs-pipeline/worker.js
+++ b/javascript-nodejs-pipeline/worker.js
@@ -7,7 +7,7 @@
 const amqp = require('amqplib');
 
 async function main() {
-    const connection = await amqp.connect('amqp://localhost');
+    const connection = await amqp.connect('amqp://rabbitmq');
     const channel = await connection.createChannel();
 
     const inputQueue = 'pipeline.input';


### PR DESCRIPTION
## Summary

Adds a supplementary Node.js example that demonstrates a hybrid consumer-and-producer pipeline.

  The example shows a worker that consumes from `pipeline.input`, transforms each message, publishes the
  result to `pipeline.output`, waits for broker confirmation, and acknowledges the original message only
  after the republished message has been confirmed.

## Flow

<img width="1225" height="72" alt="image" src="https://github.com/user-attachments/assets/b35445f0-e01c-4d76-90cf-b356f78a24da" />

## What changed

  - Added a Node.js producer that publishes sample messages
  - Added a worker that acts as both a consumer and a producer
  - Added a consumer that reads transformed messages
  - Added Docker Compose support for running the complete pipeline
  - Added README instructions for Docker Compose and manual Node.js runs
  - Added local agent notes describing the pipeline implementation pattern

  ## Validation

  - Ran docker compose up command
  - Verified the producer sent 5 messages
  - Verified the worker transformed and forwarded all 5 messages
  - Verified the consumer received all 5 transformed messages

## Contributors

- [@amburi](https://github.com/amburi)
- [@treadyaparna](https://github.com/treadyaparna)

## Related issue

Closes https://github.com/rabbitmq/rabbitmq-tutorials/issues/788