### PR TITLE
Make queue exclusive in Go AMQP 0.9.1 publisher confirms tutorial

### DIFF
--- a/go/publisher_confirms.go
+++ b/go/publisher_confirms.go
@@ -44,7 +44,7 @@ func main() {
 		"",    // name
 		false, // durability
 		false, // delete when unused
-		false, // exclusive
+		true, // exclusive
 		false, // no-wait
 		nil,   // arguments
 	)


### PR DESCRIPTION
Update the QueueDeclare call in go/publisher_confirms.go to declare an exclusive queue. This resolves compatibility issues and ensures the tutorial functions correctly with RabbitMQ 4.3.