### PR TITLE
Fix Go AMQP 1.0 RPC tutorial for RabbitMQ 4.0 onwards compatibility

### DIFF
--- a/go/rpc_amqp10.go
+++ b/go/rpc_amqp10.go
@@ -12,7 +12,7 @@ import (
 const (
 	amqpURL = "amqp://guest:guest@localhost:5672/"
 	// Request queue name for RPC requests
-	requestQueue = "rpc-requests"
+	requestQueue = "/queues/rpc-requests"
 )
 
 // RPC Server - handles ping requests and sends pong replies


### PR DESCRIPTION
Update the target queue address in the Go AMQP 1.0 RPC tutorial to use the new "v2" address format (`/queues/rpc-requests`).

RabbitMQ 4.0 deprecates the legacy "v1" un-prefixed address format and rejects it by default with an `amqp_address_v1_not_permitted` error:
```
RPC Server: Error receiving message: *Error{Condition: amqp:invalid-field, Description: Attach refused: {amqp_address_v1_not_permitted,{utf8,<<"rpc-requests">>}}, Info: map[]}
```

Adding the `/queues/` prefix ensures the tutorial works out-of-the-box on modern RabbitMQ brokers.