### PR TITLE
Implement graceful shutdown on SIGINT/SIGTERM in go (amqp091) and go-amqp(1.0) tutorials

### DIFF
--- a/go-amqp/publisher_confirms.go
+++ b/go-amqp/publisher_confirms.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
 	"os"
 	"os/signal"
@@ -13,7 +14,9 @@ import (
 const brokerURI = "amqp://guest:guest@localhost:5672/"
 
 func main() {
-	ctx := context.Background()
+	// Create a context that will be canceled on SIGINT (Ctrl+C) or SIGTERM.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
 	env := rmq.NewEnvironment(brokerURI, nil)
 	conn, err := env.NewConnection(ctx)
 	if err != nil {
@@ -31,21 +34,15 @@ func main() {
 		log.Panicf("Failed to declare a queue: %v", err)
 	}
 
-	consume(conn, qInfo.Name())
-	publish(conn, qInfo.Name(), "hello")
+	consume(ctx, conn, qInfo.Name())
+	publish(ctx, conn, qInfo.Name(), "hello")
 
 	log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
-	// Create a channel to receive OS signals
-	c := make(chan os.Signal, 1)
-	// Notify the channel for SIGINT (CTRL+C) and SIGTERM
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	// Block until a signal is received
-	<-c
+	<-ctx.Done()
 	log.Printf("Shutting down gracefully...")
 }
 
-func consume(conn *rmq.AmqpConnection, qName string) {
-	ctx := context.Background()
+func consume(ctx context.Context, conn *rmq.AmqpConnection, qName string) {
 	consumer, err := conn.NewConsumer(ctx, qName, nil)
 	if err != nil {
 		log.Panicf("Failed to create consumer: %v", err)
@@ -55,8 +52,10 @@ func consume(conn *rmq.AmqpConnection, qName string) {
 		for {
 			delivery, err := consumer.Receive(ctx)
 			if err != nil {
-				log.Printf("consumer receive: %v", err)
-				return
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				log.Panicf("Failed to receive a message: %v", err)
 			}
 			msg := delivery.Message()
 			var body string
@@ -69,8 +68,7 @@ func consume(conn *rmq.AmqpConnection, qName string) {
 	}()
 }
 
-func publish(conn *rmq.AmqpConnection, qName, text string) {
-	ctx := context.Background()
+func publish(ctx context.Context, conn *rmq.AmqpConnection, qName, text string) {
 	publisher, err := conn.NewPublisher(ctx, &rmq.QueueAddress{Queue: qName}, nil)
 	if err != nil {
 		log.Panicf("Failed to create publisher: %v", err)
@@ -79,6 +77,9 @@ func publish(conn *rmq.AmqpConnection, qName, text string) {
 
 	res, err := publisher.Publish(ctx, rmq.NewMessage([]byte(text)))
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
 		log.Panicf("Failed to publish a message: %v", err)
 	}
 	switch res.Outcome.(type) {

--- a/go-amqp/publisher_confirms.go
+++ b/go-amqp/publisher_confirms.go
@@ -3,6 +3,9 @@ package main
 import (
 	"context"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	rmq "github.com/rabbitmq/rabbitmq-amqp-go-client/pkg/rabbitmqamqp"
 )
@@ -32,7 +35,13 @@ func main() {
 	publish(conn, qInfo.Name(), "hello")
 
 	log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
-	select {}
+	// Create a channel to receive OS signals
+	c := make(chan os.Signal, 1)
+	// Notify the channel for SIGINT (CTRL+C) and SIGTERM
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	// Block until a signal is received
+	<-c
+	log.Printf("Shutting down gracefully...")
 }
 
 func consume(conn *rmq.AmqpConnection, qName string) {

--- a/go-amqp/receive.go
+++ b/go-amqp/receive.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	rmq "github.com/rabbitmq/rabbitmq-amqp-go-client/pkg/rabbitmqamqp"
 )
@@ -11,7 +14,10 @@ import (
 const brokerURI = "amqp://guest:guest@localhost:5672/"
 
 func main() {
-	ctx := context.Background()
+	// Create a context that will be canceled on SIGINT (Ctrl+C) or SIGTERM.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel() // Ensure resources are freed
+
 	env := rmq.NewEnvironment(brokerURI, nil)
 	conn, err := env.NewConnection(ctx)
 	if err != nil {
@@ -37,6 +43,7 @@ func main() {
 		delivery, err := consumer.Receive(ctx)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
+				log.Printf("Shutting down gracefully...")
 				return
 			}
 			log.Panicf("Failed to receive a message: %v", err)

--- a/go-amqp/receive.go
+++ b/go-amqp/receive.go
@@ -16,7 +16,7 @@ const brokerURI = "amqp://guest:guest@localhost:5672/"
 func main() {
 	// Create a context that will be canceled on SIGINT (Ctrl+C) or SIGTERM.
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer cancel() // Ensure resources are freed
+	defer cancel()
 
 	env := rmq.NewEnvironment(brokerURI, nil)
 	conn, err := env.NewConnection(ctx)

--- a/go-amqp/receive_logs.go
+++ b/go-amqp/receive_logs.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	rmq "github.com/rabbitmq/rabbitmq-amqp-go-client/pkg/rabbitmqamqp"
 )
@@ -11,7 +14,10 @@ import (
 const brokerURI = "amqp://guest:guest@localhost:5672/"
 
 func main() {
-	ctx := context.Background()
+	// Create a context that will be canceled on SIGINT (Ctrl+C) or SIGTERM.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel() // Ensure resources are freed
+
 	env := rmq.NewEnvironment(brokerURI, nil)
 	conn, err := env.NewConnection(ctx)
 	if err != nil {
@@ -54,6 +60,7 @@ func main() {
 		delivery, err := consumer.Receive(ctx)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
+				log.Printf("Shutting down gracefully...")
 				return
 			}
 			log.Panicf("Failed to receive a message: %v", err)

--- a/go-amqp/receive_logs.go
+++ b/go-amqp/receive_logs.go
@@ -16,7 +16,7 @@ const brokerURI = "amqp://guest:guest@localhost:5672/"
 func main() {
 	// Create a context that will be canceled on SIGINT (Ctrl+C) or SIGTERM.
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer cancel() // Ensure resources are freed
+	defer cancel()
 
 	env := rmq.NewEnvironment(brokerURI, nil)
 	conn, err := env.NewConnection(ctx)

--- a/go-amqp/receive_logs_direct.go
+++ b/go-amqp/receive_logs_direct.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 
 	rmq "github.com/rabbitmq/rabbitmq-amqp-go-client/pkg/rabbitmqamqp"
 )
@@ -12,7 +14,10 @@ import (
 const brokerURI = "amqp://guest:guest@localhost:5672/"
 
 func main() {
-	ctx := context.Background()
+	// Create a context that will be canceled on SIGINT (Ctrl+C) or SIGTERM.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel() // Ensure resources are freed
+
 	env := rmq.NewEnvironment(brokerURI, nil)
 	conn, err := env.NewConnection(ctx)
 	if err != nil {
@@ -62,6 +67,7 @@ func main() {
 		delivery, err := consumer.Receive(ctx)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
+				log.Printf("Shutting down gracefully...")
 				return
 			}
 			log.Panicf("Failed to receive a message: %v", err)

--- a/go-amqp/receive_logs_direct.go
+++ b/go-amqp/receive_logs_direct.go
@@ -16,7 +16,7 @@ const brokerURI = "amqp://guest:guest@localhost:5672/"
 func main() {
 	// Create a context that will be canceled on SIGINT (Ctrl+C) or SIGTERM.
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer cancel() // Ensure resources are freed
+	defer cancel()
 
 	env := rmq.NewEnvironment(brokerURI, nil)
 	conn, err := env.NewConnection(ctx)

--- a/go-amqp/receive_logs_topic.go
+++ b/go-amqp/receive_logs_topic.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 
 	rmq "github.com/rabbitmq/rabbitmq-amqp-go-client/pkg/rabbitmqamqp"
 )
@@ -12,7 +14,10 @@ import (
 const brokerURI = "amqp://guest:guest@localhost:5672/"
 
 func main() {
-	ctx := context.Background()
+	// Create a context that will be canceled on SIGINT (Ctrl+C) or SIGTERM.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel() // Ensure resources are freed
+
 	env := rmq.NewEnvironment(brokerURI, nil)
 	conn, err := env.NewConnection(ctx)
 	if err != nil {
@@ -62,6 +67,7 @@ func main() {
 		delivery, err := consumer.Receive(ctx)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
+				log.Printf("Shutting down gracefully...")
 				return
 			}
 			log.Panicf("Failed to receive a message: %v", err)

--- a/go-amqp/receive_logs_topic.go
+++ b/go-amqp/receive_logs_topic.go
@@ -16,7 +16,7 @@ const brokerURI = "amqp://guest:guest@localhost:5672/"
 func main() {
 	// Create a context that will be canceled on SIGINT (Ctrl+C) or SIGTERM.
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer cancel() // Ensure resources are freed
+	defer cancel()
 
 	env := rmq.NewEnvironment(brokerURI, nil)
 	conn, err := env.NewConnection(ctx)

--- a/go-amqp/worker.go
+++ b/go-amqp/worker.go
@@ -18,7 +18,7 @@ const brokerURI = "amqp://guest:guest@localhost:5672/"
 func main() {
 	// Create a context that will be canceled on SIGINT (Ctrl+C) or SIGTERM.
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer cancel() // Ensure resources are freed
+	defer cancel()
 
 	env := rmq.NewEnvironment(brokerURI, nil)
 	conn, err := env.NewConnection(ctx)

--- a/go-amqp/worker.go
+++ b/go-amqp/worker.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"errors"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	rmq "github.com/rabbitmq/rabbitmq-amqp-go-client/pkg/rabbitmqamqp"
@@ -13,7 +16,10 @@ import (
 const brokerURI = "amqp://guest:guest@localhost:5672/"
 
 func main() {
-	ctx := context.Background()
+	// Create a context that will be canceled on SIGINT (Ctrl+C) or SIGTERM.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel() // Ensure resources are freed
+
 	env := rmq.NewEnvironment(brokerURI, nil)
 	conn, err := env.NewConnection(ctx)
 	if err != nil {
@@ -39,6 +45,7 @@ func main() {
 		delivery, err := consumer.Receive(ctx)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
+				log.Printf("Shutting down gracefully...")
 				return
 			}
 			log.Panicf("Failed to receive a message: %v", err)

--- a/go/publisher_confirms.go
+++ b/go/publisher_confirms.go
@@ -3,6 +3,9 @@ package main
 import (
 	"context"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -44,7 +47,7 @@ func main() {
 		"",    // name
 		false, // durability
 		false, // delete when unused
-		true, // exclusive
+		true,  // exclusive
 		false, // no-wait
 		nil,   // arguments
 	)
@@ -54,8 +57,14 @@ func main() {
 	publish(ch, q.Name, "hello")
 
 	log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
-	var forever chan struct{}
-	<-forever
+	// Create a channel to receive OS signals
+	c := make(chan os.Signal, 1)
+	// Notify the channel for SIGINT (CTRL+C) and SIGTERM
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	// Block until a signal is received
+	<-c
+	log.Printf("Shutting down gracefully...")
+	// Deferred conn.Close() and ch.Close() will execute!
 }
 
 func consume(ch *amqp.Channel, qName string) {

--- a/go/receive.go
+++ b/go/receive.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -44,8 +47,6 @@ func main() {
 	)
 	failOnError(err, "Failed to register a consumer")
 
-	var forever chan struct{}
-
 	go func() {
 		for d := range msgs {
 			log.Printf("Received a message: %s", d.Body)
@@ -53,5 +54,12 @@ func main() {
 	}()
 
 	log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
-	<-forever
+	// Create a channel to receive OS signals
+	c := make(chan os.Signal, 1)
+	// Notify the channel for SIGINT (CTRL+C) and SIGTERM
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	// Block until a signal is received
+	<-c
+	log.Printf("Shutting down gracefully...")
+	// Deferred conn.Close() and ch.Close() will execute!
 }

--- a/go/receive_logs.go
+++ b/go/receive_logs.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -61,8 +64,6 @@ func main() {
 	)
 	failOnError(err, "Failed to register a consumer")
 
-	var forever chan struct{}
-
 	go func() {
 		for d := range msgs {
 			log.Printf(" [x] %s", d.Body)
@@ -70,5 +71,12 @@ func main() {
 	}()
 
 	log.Printf(" [*] Waiting for logs. To exit press CTRL+C")
-	<-forever
+	// Create a channel to receive OS signals
+	c := make(chan os.Signal, 1)
+	// Notify the channel for SIGINT (CTRL+C) and SIGTERM
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	// Block until a signal is received
+	<-c
+	log.Printf("Shutting down gracefully...")
+	// Deferred conn.Close() and ch.Close() will execute!
 }

--- a/go/receive_logs_direct.go
+++ b/go/receive_logs_direct.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -69,8 +71,6 @@ func main() {
 	)
 	failOnError(err, "Failed to register a consumer")
 
-	var forever chan struct{}
-
 	go func() {
 		for d := range msgs {
 			log.Printf(" [x] %s", d.Body)
@@ -78,5 +78,12 @@ func main() {
 	}()
 
 	log.Printf(" [*] Waiting for logs. To exit press CTRL+C")
-	<-forever
+	// Create a channel to receive OS signals
+	c := make(chan os.Signal, 1)
+	// Notify the channel for SIGINT (CTRL+C) and SIGTERM
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	// Block until a signal is received
+	<-c
+	log.Printf("Shutting down gracefully...")
+	// Deferred conn.Close() and ch.Close() will execute!
 }

--- a/go/receive_logs_topic.go
+++ b/go/receive_logs_topic.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -69,8 +71,6 @@ func main() {
 	)
 	failOnError(err, "Failed to register a consumer")
 
-	var forever chan struct{}
-
 	go func() {
 		for d := range msgs {
 			log.Printf(" [x] %s", d.Body)
@@ -78,5 +78,12 @@ func main() {
 	}()
 
 	log.Printf(" [*] Waiting for logs. To exit press CTRL+C")
-	<-forever
+	// Create a channel to receive OS signals
+	c := make(chan os.Signal, 1)
+	// Notify the channel for SIGINT (CTRL+C) and SIGTERM
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	// Block until a signal is received
+	<-c
+	log.Printf("Shutting down gracefully...")
+	// Deferred conn.Close() and ch.Close() will execute!
 }

--- a/go/rpc_amqp10.go
+++ b/go/rpc_amqp10.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/Azure/go-amqp"
@@ -227,6 +230,16 @@ func main() {
 	}()
 
 	// Wait for context cancellation (Ctrl+C or error)
+	// Create a channel to receive OS signals
+	c := make(chan os.Signal, 1)
+	// Notify the channel for SIGINT (CTRL+C) and SIGTERM
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		// Block until a signal is received
+		<-c
+		log.Println("\nReceived interrupt, shutting down...")
+		cancel()
+	}()
 	<-ctx.Done()
 	log.Println("Application shutting down...")
 }

--- a/go/worker.go
+++ b/go/worker.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -53,8 +56,6 @@ func main() {
 	)
 	failOnError(err, "Failed to register a consumer")
 
-	var forever chan struct{}
-
 	go func() {
 		for d := range msgs {
 			log.Printf("Received a message: %s", d.Body)
@@ -67,5 +68,12 @@ func main() {
 	}()
 
 	log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
-	<-forever
+	// Create a channel to receive OS signals
+	c := make(chan os.Signal, 1)
+	// Notify the channel for SIGINT (CTRL+C) and SIGTERM
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	// Block until a signal is received
+	<-c
+	log.Printf("Shutting down gracefully...")
+	// Deferred conn.Close() and ch.Close() will execute!
 }


### PR DESCRIPTION
Replace infinite blocking channels (`<-forever`, `select {}`) with OS signal handling to allow graceful shutdown when a user presses CTRL+C. 
For the `go-amqp` tutorials, `context.Background()` was updated to use `signal.NotifyContext(..., os.Interrupt, syscall.SIGTERM)` to automatically propagate cancellation to consumers. 
For the `go` (amqp091-go) tutorials, `os/signal` channels are used to block the main thread until an interrupt signal is received. 
This ensures that deferred connection and channel closures (`conn.Close()`, `ch.Close()`) actually execute, allowing the client to send the proper AMQP connection close frames instead of abruptly severing the TCP socket.