### PR TITLE
Expand Go publisher confirms tutorial with batch and async strategies

### DIFF
--- a/go/publisher_confirms.go
+++ b/go/publisher_confirms.go
@@ -5,11 +5,15 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strconv"
+	"sync"
 	"syscall"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
+
+const MessageCount = 50000
 
 func failOnError(err error, msg string) {
 	if err != nil {
@@ -17,81 +21,201 @@ func failOnError(err error, msg string) {
 	}
 }
 
+// Create a channel in confirm mode on the given connection
+func openConfirmChannel(conn *amqp.Connection) *amqp.Channel {
+	ch, err := conn.Channel()
+	failOnError(err, "Failed to open a channel")
+
+	err = ch.Confirm(false)
+	failOnError(err, "Failed to put channel into confirm mode")
+
+	return ch
+}
+
 func main() {
 	conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
 	failOnError(err, "Failed to connect to RabbitMQ")
 	defer conn.Close()
 
-	ch, err := conn.Channel()
-	failOnError(err, "Failed to open a channel")
+	// Create a context that will be canceled on SIGINT (Ctrl+C) or SIGTERM.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	handlePublisherConfirmsIndividually(ctx, conn)
+	handlePublisherConfirmsInBatches(ctx, conn)
+	handlePublisherConfirmsAsynchronously(ctx, conn)
+}
+
+// Handle publisher confirms individually (synchronous)
+func handlePublisherConfirmsIndividually(parentCtx context.Context, conn *amqp.Connection) {
+	ch := openConfirmChannel(conn)
 	defer ch.Close()
 
-	confirms := make(chan amqp.Confirmation)
-	ch.NotifyPublish(confirms)
+	q, err := ch.QueueDeclare("", false, false, true, false, nil)
+	failOnError(err, "Failed to declare a queue")
+
+	confirmDeferred := ch.NotifyPublish(make(chan amqp.Confirmation, 1))
+
+	ctx, cancel := context.WithTimeout(parentCtx, 60*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	for i := 0; i < MessageCount; i++ {
+		body := strconv.Itoa(i)
+		err = ch.PublishWithContext(ctx, "", q.Name, false, false, amqp.Publishing{
+			ContentType: "text/plain",
+			Body:        []byte(body),
+		})
+		failOnError(err, "Failed to publish a message")
+
+		// Wait for confirmation
+		select {
+		case confirm := <-confirmDeferred:
+			if !confirm.Ack {
+				log.Printf("Message %d was nacked by the broker", confirm.DeliveryTag)
+			}
+		case <-ctx.Done():
+			log.Printf("Timeout waiting for confirmation: %v", ctx.Err())
+			return
+		}
+	}
+
+	duration := time.Since(start)
+	log.Printf("Published %d messages and handled confirms individually in %v\n", MessageCount, duration)
+}
+
+// Handle publisher confirms in batches (synchronous)
+func handlePublisherConfirmsInBatches(parentCtx context.Context, conn *amqp.Connection) {
+	ch := openConfirmChannel(conn)
+	defer ch.Close()
+
+	batchSize := 100
+
+	q, err := ch.QueueDeclare("", false, false, true, false, nil)
+	failOnError(err, "Failed to declare a queue")
+
+	confirmDeferred := ch.NotifyPublish(make(chan amqp.Confirmation, batchSize))
+
+	ctx, cancel := context.WithTimeout(parentCtx, 10*time.Second)
+	defer cancel()
+
+	outstandingMessageCount := 0
+	start := time.Now()
+
+	for i := 0; i < MessageCount; i++ {
+		body := strconv.Itoa(i)
+		err = ch.PublishWithContext(ctx, "", q.Name, false, false, amqp.Publishing{
+			ContentType: "text/plain",
+			Body:        []byte(body),
+		})
+		failOnError(err, "Failed to publish a message")
+
+		outstandingMessageCount++
+
+		if outstandingMessageCount == batchSize {
+			// Wait for all confirms for this batch
+			for j := 0; j < batchSize; j++ {
+				select {
+				case confirm := <-confirmDeferred:
+					if !confirm.Ack {
+						log.Printf("Message %d in batch was nacked", confirm.DeliveryTag)
+					}
+				case <-ctx.Done():
+					log.Printf("Timeout waiting for batch confirmation: %v", ctx.Err())
+					return
+				}
+			}
+			outstandingMessageCount = 0
+		}
+	}
+
+	// Wait for remaining confirms left over in the final uneven batch
+	if outstandingMessageCount > 0 {
+		for j := 0; j < outstandingMessageCount; j++ {
+			select {
+			case confirm := <-confirmDeferred:
+				if !confirm.Ack {
+					log.Printf("Message %d in batch was nacked", confirm.DeliveryTag)
+				}
+			case <-ctx.Done():
+				log.Printf("Timeout waiting for remaining batch confirmation: %v", ctx.Err())
+				return
+			}
+		}
+	}
+
+	duration := time.Since(start)
+	log.Printf("Published %d messages and handled confirms in batches in %v\n", MessageCount, duration)
+}
+
+// Handle publisher confirms asynchronously
+func handlePublisherConfirmsAsynchronously(parentCtx context.Context, conn *amqp.Connection) {
+	ch := openConfirmChannel(conn)
+	defer ch.Close()
+
+	q, err := ch.QueueDeclare("", false, false, true, false, nil)
+	failOnError(err, "Failed to declare a queue")
+
+	confirmDeferred := ch.NotifyPublish(make(chan amqp.Confirmation, MessageCount))
+
+	var outstandingConfirms sync.Map
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	ctx, cancel := context.WithTimeout(parentCtx, 10*time.Second)
+	defer cancel()
+
+	// Goroutine responsible for listening to incoming confirms asynchronously
 	go func() {
-		for confirm := range confirms {
-			if confirm.Ack {
-				// code when messages is confirmed
-				log.Printf("Confirmed")
-			} else {
-				// code when messages is nack-ed
-				log.Printf("Nacked")
+		defer wg.Done()
+		confirmedCount := 0
+		for {
+			select {
+			case confirm := <-confirmDeferred:
+				// Clean up map when confirms received
+				if body, exists := outstandingConfirms.LoadAndDelete(confirm.DeliveryTag); exists {
+					if !confirm.Ack {
+						log.Printf("Message with body %s has been nack-ed. Delivery tag: %d", body, confirm.DeliveryTag)
+					}
+				}
+				confirmedCount++
+				if confirmedCount == MessageCount {
+					return
+				}
+			case <-ctx.Done():
+				log.Printf("Timeout waiting for asynchronous confirmation: %v", ctx.Err())
+				return
 			}
 		}
 	}()
 
-	err = ch.Confirm(false)
-	failOnError(err, "Failed to confirm")
+	start := time.Now()
+	// seqNo starts tracking delivery tags on the channel
+	var seqNo uint64 = 1
 
-	q, err := ch.QueueDeclare(
-		"",    // name
-		false, // durability
-		false, // delete when unused
-		true,  // exclusive
-		false, // no-wait
-		nil,   // arguments
-	)
-	failOnError(err, "Failed to declare a queue")
-
-	consume(ch, q.Name)
-	publish(ch, q.Name, "hello")
-
-	log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
-	// Create a channel to receive OS signals
-	c := make(chan os.Signal, 1)
-	// Notify the channel for SIGINT (CTRL+C) and SIGTERM
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	// Block until a signal is received
-	<-c
-	log.Printf("Shutting down gracefully...")
-	// Deferred conn.Close() and ch.Close() will execute!
-}
-
-func consume(ch *amqp.Channel, qName string) {
-	msgs, err := ch.Consume(
-		qName, // queue
-		"",    // consumer
-		true,  // auto-ack
-		false, // exclusive
-		false, // no-local
-		false, // no-wait
-		nil,   // args
-	)
-	failOnError(err, "Failed to register a consumer")
-
-	go func() {
-		for d := range msgs {
-			log.Printf("Received a message: %s", d.Body)
+	for i := 0; i < MessageCount; i++ {
+		// Explicitly check if context is canceled
+		select {
+		case <-ctx.Done():
+			wg.Wait() // Wait for the listener goroutine to exit
+			return
+		default:
+			// Context is active, proceed
 		}
-	}()
-}
+		body := strconv.Itoa(i)
+		outstandingConfirms.Store(seqNo, body)
+		seqNo++
 
-func publish(ch *amqp.Channel, qName, text string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	err := ch.PublishWithContext(ctx, "", qName, false, false, amqp.Publishing{
-		ContentType: "text/plain",
-		Body:        []byte(text),
-	})
-	failOnError(err, "Failed to publish a message")
+		err = ch.PublishWithContext(ctx, "", q.Name, false, false, amqp.Publishing{
+			ContentType: "text/plain",
+			Body:        []byte(body),
+		})
+		failOnError(err, "Failed to publish a message")
+	}
+
+	// Wait for the async goroutine listener to finish processing all confirmations
+	wg.Wait()
+
+	duration := time.Since(start)
+	log.Printf("Published %d messages and handled confirms asynchronously in %v\n", MessageCount, duration)
 }

--- a/go/publisher_confirms.go
+++ b/go/publisher_confirms.go
@@ -190,8 +190,6 @@ func handlePublisherConfirmsAsynchronously(parentCtx context.Context, conn *amqp
 	}()
 
 	start := time.Now()
-	// seqNo starts tracking delivery tags on the channel
-	var seqNo uint64 = 1
 
 	for i := 0; i < MessageCount; i++ {
 		// Explicitly check if context is canceled
@@ -203,8 +201,7 @@ func handlePublisherConfirmsAsynchronously(parentCtx context.Context, conn *amqp
 			// Context is active, proceed
 		}
 		body := strconv.Itoa(i)
-		outstandingConfirms.Store(seqNo, body)
-		seqNo++
+		outstandingConfirms.Store(ch.GetNextPublishSeqNo(), body)
 
 		err = ch.PublishWithContext(ctx, "", q.Name, false, false, amqp.Publishing{
 			ContentType: "text/plain",


### PR DESCRIPTION
Previously, the publisher confirms tutorial only demonstrated confirming a single message individually. This commit significantly expands the tutorial to cover real-world scenarios by publishing multiple messages using three distinct strategies:

- Individual confirms: Synchronously waiting for a confirmation after every published message in a loop.
- Batched confirms: Publishing messages in batches and waiting for all confirmations synchronously to improve throughput.
- Asynchronous confirms: Using a background goroutine and a thread-safe `sync.Map` to process confirmations asynchronously while continuing to publish, offering the best performance.

Additionally, context timeout handling (`ctx.Done()`) has been integrated into all three methods to ensure the application fails gracefully rather than deadlocking if broker confirmations are delayed or lost.

Output:
1. Without interrupt
```
2026/05/21 20:13:32 Published 50000 messages and handled confirms individually in 28.216412974s
2026/05/21 20:13:37 Published 50000 messages and handled confirms in batches in 4.897829699s
2026/05/21 20:13:40 Published 50000 messages and handled confirms asynchronously in 3.444272199s
```
2. With interrupt
```
^C2026/05/21 20:13:47 Timeout waiting for confirmation: context canceled
2026/05/21 20:13:47 Timeout waiting for batch confirmation: context canceled
2026/05/21 20:13:47 Timeout waiting for asynchronous confirmation: context canceled
```