### PR TITLE
fix: correct property name for main class since gradle version 8.0

### DIFF
--- a/java-gradle/build.gradle
+++ b/java-gradle/build.gradle
@@ -24,6 +24,6 @@ test {
 }
 
 application {
-    mainClassName = project.hasProperty("main") ?
+    mainClass = project.hasProperty("main") ?
             project.getProperty("main") : "NULL"
 }


### PR DESCRIPTION
### Fixes the error 
```
Could not set unknown property 'mainClassName' for extension 'application' of type org.gradle.api.plugins.internal.DefaultJavaApplication.
```
on trying to build (or, run individual java class) in the java-gradle project


### RCA:
Since gradle 8.0, `mainClassName` property is removed. `mainClass` is to be used instead
> The deprecated mainClassName property of the JavaApplication interface has been removed. Use the mainClass property instead.
Refer: [Gradle 8.0 Upgrade Guide](https://docs.gradle.org/current/userguide/upgrading_version_7.html#javaapplication_api_cleanup)

Gradle version being used in project is 9.5.1 Refer: [java-gradle/gradle/wrapper/gradle-wrapper.properties
](https://github.com/rabbitmq/rabbitmq-tutorials/blob/f920ea23ca1e73af32d9b4302f5c6bdc0abf6328/java-gradle/gradle/wrapper/gradle-wrapper.properties#L3)
### Steps to Replicate the error (linux):
- `cd java-gradle` (Assuming pwd = root of repo)
- `./gradlew run -Pmain=Send`