### PR TITLE
Elixir Stream: keep the stream consumer running until closed

### DIFF
--- a/elixir-stream/consume.exs
+++ b/elixir-stream/consume.exs
@@ -13,15 +13,29 @@ Mix.install([
 # it should be still be good to go.
 RabbitMQStream.Connection.create_stream(connection, "my_stream")
 
-# Now we can subscribe to the stream, receiving up to 1 chunk.
-{:ok, subscription_id} =
-  RabbitMQStream.Connection.subscribe(connection, "my_stream", self(), :first, 1)
+# subscribe/5 must be called from the process that will run `receive`, since that's
+# the process the server delivers messages to.
+consumer_task =
+  Task.async(fn ->
+    # Subscribe to the stream, receiving up to 1 chunk.
+    {:ok, subscription_id} =
+      RabbitMQStream.Connection.subscribe(connection, "my_stream", self(), :first, 1)
 
-# Now we can consume the messages
-receive do
-  # Each 'deliver' data comes inside a Chunk, which may contain multiple messages
-  {:deliver, %{subscription_id: ^subscription_id, osiris_chunk: chunk}} ->
-    for message <- chunk.data_entries do
-      Logger.info("Received: #{inspect(message)}")
-    end
-end
+    Stream.repeatedly(fn ->
+      receive do
+        # A chunk may contain multiple messages. We only have 1 credit, so we top it
+        # back up after each chunk to keep them coming.
+        {:deliver, %{subscription_id: ^subscription_id, osiris_chunk: chunk}} ->
+          for message <- chunk.data_entries do
+            Logger.info("Received: #{inspect(message)}")
+          end
+
+          RabbitMQStream.Connection.credit(connection, subscription_id, 1)
+      end
+    end)
+    |> Stream.run()
+  end)
+
+IO.gets(" [x] Waiting for messages. Press enter to close the consumer\n")
+
+Task.shutdown(consumer_task, :brutal_kill)


### PR DESCRIPTION
The consumer only ever handled a single `:deliver` message (one chunk) before falling through and exiting, and the subscription was granted just 1 credit, so the server wouldn't push more chunks anyway. Loop the receive inside a Task, renewing credit after each chunk, and wait on stdin so the consumer keeps running until Enter is pressed.