### PR TITLE
Elixir Stream: Add Elixir offset tracking stream tutorial

### DIFF
--- a/elixir-stream/README.md
+++ b/elixir-stream/README.md
@@ -4,7 +4,7 @@ Here you can find Elixir code examples from [RabbitMQ tutorials](https://www.rab
 
 ## Requirements
 
-These examples use the [`VictorGaiva/rabbitmq-stream`](https://github.com/VictorGaiva/rabbitmq-stream) client library.
+These examples use the [`rabbitmq-community/rabbitmq-stream-elixir-client`](https://github.com/rabbitmq-community/rabbitmq-stream-elixir-client) client library.
 
 The dependencies are installed during the exection of the examples using `Mix.install/1`
 
@@ -22,4 +22,14 @@ elixir publish.exs
 elixir consume.exs
 ```
 
-To learn more, see [`VictorGaiva/rabbitmq-stream`](https://github.com/VictorGaiva/rabbitmq-stream).
+Offset tracking tutorial:
+
+``` shell
+# run the publisher
+elixir offset_tracking_send.exs
+
+# run the consumer
+elixir offset_tracking_receive.exs
+```
+
+To learn more, see [`rabbitmq-community/rabbitmq-stream-elixir-client`](https://github.com/rabbitmq-community/rabbitmq-stream-elixir-client).

--- a/elixir-stream/offset_tracking_receive.exs
+++ b/elixir-stream/offset_tracking_receive.exs
@@ -1,0 +1,73 @@
+#! /usr/bin/env elixir
+require Logger
+
+# Installing the rabbitmq_stream Library
+Mix.install([
+  {:rabbitmq_stream, "~> 0.4.1"}
+])
+
+# First we start a Connection to the RabbitMQ Server
+{:ok, connection} = RabbitMQStream.Connection.start_link()
+
+stream_name = "stream-offset-tracking-elixir"
+consumer_reference = "offset-tracking-tutorial"
+
+# We can assume the stream doesn't exist yet, and attempt to create it. If it already exists,
+# it should be still be good to go.
+RabbitMQStream.Connection.create_stream(connection, stream_name)
+
+# If we already stored an offset under this reference in a previous run, resume right after
+# it. Otherwise, start from the beginning of the stream.
+offset_specification =
+  case RabbitMQStream.Connection.query_offset(connection, stream_name, consumer_reference) do
+    {:ok, stored_offset} -> {:offset, stored_offset + 1}
+    {:error, :no_offset} -> :first
+  end
+
+{:ok, subscription_id} =
+  RabbitMQStream.Connection.subscribe(connection, stream_name, self(), offset_specification, 10)
+
+Logger.info("Started consuming...")
+
+# Consumes chunks of messages until the "marker" message is found, storing the offset every
+# 10 messages, and once more when the marker is reached.
+consume = fn consume, message_count, first_offset, last_offset ->
+  receive do
+    {:deliver, %{subscription_id: ^subscription_id, osiris_chunk: chunk}} ->
+      # Every entry in a chunk occupies one offset, starting at the chunk's own offset.
+      entries = Enum.with_index(chunk.data_entries, chunk.chunk_id)
+
+      {message_count, first_offset, last_offset, marker_found?} =
+        Enum.reduce(entries, {message_count, first_offset, last_offset, false}, fn {data, offset},
+                                                                                     {message_count, first_offset,
+                                                                                      last_offset, _marker_found?} ->
+          if first_offset == nil, do: Logger.info("First message received.")
+          first_offset = first_offset || offset
+
+          message_count = message_count + 1
+          if rem(message_count, 10) == 0 do
+            RabbitMQStream.Connection.store_offset(connection, stream_name, consumer_reference, offset)
+          end
+
+          if data == "marker" do
+            RabbitMQStream.Connection.store_offset(connection, stream_name, consumer_reference, offset)
+            {message_count, first_offset, offset, true}
+          else
+            {message_count, first_offset, last_offset, false}
+          end
+        end)
+
+      if marker_found? do
+        RabbitMQStream.Connection.unsubscribe(connection, subscription_id)
+        {first_offset, last_offset}
+      else
+        # Replenish the credit spent on the chunk we just consumed, so the server keeps sending.
+        RabbitMQStream.Connection.credit(connection, subscription_id, 1)
+        consume.(consume, message_count, first_offset, last_offset)
+      end
+  end
+end
+
+{first_offset, last_offset} = consume.(consume, 0, nil, nil)
+
+Logger.info("Done consuming, first offset #{first_offset}, last offset #{last_offset}.")

--- a/elixir-stream/offset_tracking_send.exs
+++ b/elixir-stream/offset_tracking_send.exs
@@ -1,0 +1,58 @@
+#! /usr/bin/env elixir
+require Logger
+
+# Installing the rabbitmq_stream Library
+Mix.install([
+  {:rabbitmq_stream, "~> 0.4.1"}
+])
+
+# First we start a Connection to the RabbitMQ Server
+{:ok, connection} = RabbitMQStream.Connection.start_link()
+
+stream_name = "stream-offset-tracking-elixir"
+producer_reference = "offset-tracking-producer"
+
+# We can assume the stream doesn't exist yet, and attempt to create it. If it already exists,
+# it should be still be good to go.
+RabbitMQStream.Connection.create_stream(connection, stream_name)
+
+# Before publishing a message, we need to declare a producer. It is required by the
+# RabbitMQ Server to prevent message duplication.
+{:ok, producer_id} =
+  RabbitMQStream.Connection.declare_producer(connection, stream_name, producer_reference)
+
+# Each producer has a sequence number, that must be published with the message, and
+# incremented after each message.
+{:ok, sequence_number} =
+  RabbitMQStream.Connection.query_producer_sequence(connection, stream_name, producer_reference)
+
+message_count = 100
+
+Logger.info("Publishing #{message_count} messages...")
+
+for i <- 1..message_count do
+  # The last message is a "marker", letting the consumer know it has caught up with
+  # every message published during this run.
+  body = if i == message_count, do: "marker", else: "hello"
+
+  :ok = RabbitMQStream.Connection.publish(connection, producer_id, sequence_number + i, body)
+end
+
+# `publish/5` doesn't wait for the server's confirmation, so we poll the sequence number
+# the server tracks for this producer, until it catches up with the last message we sent.
+# This tells us every message has been safely persisted to the stream.
+last_sequence_number = sequence_number + message_count
+
+wait_for_confirmation = fn wait_for_confirmation ->
+  {:ok, confirmed_sequence_number} =
+    RabbitMQStream.Connection.query_producer_sequence(connection, stream_name, producer_reference)
+
+  unless confirmed_sequence_number >= last_sequence_number do
+    Process.sleep(50)
+    wait_for_confirmation.(wait_for_confirmation)
+  end
+end
+
+wait_for_confirmation.(wait_for_confirmation)
+
+Logger.info("Messages confirmed.")


### PR DESCRIPTION
Adds offset_tracking_send.exs / offset_tracking_receive.exs mirroring the go-stream offset tracking example, using the raw RabbitMQStream.Connection API to publish 100 messages (marker last) and resume consumption from a stored offset, storing progress every 10 messages and on the marker. Also repoints README.md to the rabbitmq-community/rabbitmq-stream-elixir-client library.

Sample output:
```
  $ elixir offset_tracking_send.exs
  15:16:02.087 [info] Publishing 100 messages...
  15:16:02.143 [info] Messages confirmed.

  $ elixir offset_tracking_receive.exs
  15:16:05.201 [info] Started consuming...
  15:16:05.204 [info] First message received.
  15:16:05.210 [info] Done consuming, first offset 0, last offset 99.
```